### PR TITLE
safer publish way

### DIFF
--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -98,7 +98,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install -U setuptools twine build
+          pip install -U setuptools build
       - name: Build
         run: |
           git tag

--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -87,6 +87,8 @@ jobs:
     needs: [test]
     runs-on: ubuntu-latest
     if: contains(github.ref, 'tags')
+    permissions:
+      id-token: write
     steps:
       - uses: actions/checkout@v2
       - name: Set up Python
@@ -97,11 +99,9 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install -U setuptools twine build
-      - name: Build and publish
-        env:
-          TWINE_USERNAME: __token__
-          TWINE_PASSWORD: ${{ secrets.TWINE_API_KEY }}
+      - name: Build
         run: |
           git tag
           python -m build
-          twine upload dist/*
+      - name: Publish package distributions to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1


### PR DESCRIPTION
Recently pypi has implemented a safer way for publishing python package releases without the need to generate and provide tokens. It requires correct implementation in publishing section of project settings on pypi.

![obraz](https://github.com/napari/napari-plugin-manager/assets/3826210/a1b781cd-d374-4780-8458-959f5d88d61d)

I have already implemented this in this project and it works:
https://github.com/Czaki/local-migrator/blob/8cb1a62d6520f0a33d8190c88ec737ea72d9b6d6/.github/workflows/tests.yml#L84-L108