### PR TITLE
Temporary remove napari from dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,6 @@ classifiers = [
 ]
 requires-python = ">=3.8"
 dependencies = [
-  "napari",
   "npe2",
   "qtpy",
   "superqt",


### PR DESCRIPTION
Because of problems with pinnign dependencies in napari, I need to remove napari from dependencies.