### PR TITLE
[FIX] Do not mark plugins as unavailable on conda when not running from a constructor bundle

### DIFF
--- a/napari_plugin_manager/_tests/test_qt_plugin_dialog.py
+++ b/napari_plugin_manager/_tests/test_qt_plugin_dialog.py
@@ -213,7 +213,7 @@ def test_filter_not_available_plugins(request, plugin_dialog):
     The second plugin ("test-name-1") is available on conda-forge and
     should be enabled without the tooltip warning.
     """
-    if "no-constructor" not in request.node.name:
+    if "no-constructor" in request.node.name:
         # the plugin_dialog fixture has this id
         # skip for 'constructor' variant
         pytest.skip()

--- a/napari_plugin_manager/_tests/test_qt_plugin_dialog.py
+++ b/napari_plugin_manager/_tests/test_qt_plugin_dialog.py
@@ -214,7 +214,9 @@ def test_filter_not_available_plugins(request, plugin_dialog):
     should be enabled without the tooltip warning.
     """
     if "no-constructor" in request.node.name:
-        pytest.skip(reason="This test is only relevant for constructor-based installs")
+        pytest.skip(
+            reason="This test is only relevant for constructor-based installs"
+        )
     item = plugin_dialog.available_list.item(0)
     widget = plugin_dialog.available_list.itemWidget(item)
     if widget:
@@ -261,7 +263,9 @@ def test_visible_widgets(request, plugin_dialog):
     Test that the direct entry button and textbox are visible
     """
     if "no-constructor" not in request.node.name:
-        pytest.skip(reason="Tested functionality not available in constructor-based installs")
+        pytest.skip(
+            reason="Tested functionality not available in constructor-based installs"
+        )
     assert plugin_dialog.direct_entry_edit.isVisible()
     assert plugin_dialog.direct_entry_btn.isVisible()
 

--- a/napari_plugin_manager/_tests/test_qt_plugin_dialog.py
+++ b/napari_plugin_manager/_tests/test_qt_plugin_dialog.py
@@ -214,9 +214,7 @@ def test_filter_not_available_plugins(request, plugin_dialog):
     should be enabled without the tooltip warning.
     """
     if "no-constructor" in request.node.name:
-        # the plugin_dialog fixture has this id
-        # skip for 'constructor' variant
-        pytest.skip()
+        pytest.skip(reason="This test is only relevant for constructor-based installs")
     item = plugin_dialog.available_list.item(0)
     widget = plugin_dialog.available_list.itemWidget(item)
     if widget:
@@ -263,14 +261,12 @@ def test_visible_widgets(request, plugin_dialog):
     Test that the direct entry button and textbox are visible
     """
     if "no-constructor" not in request.node.name:
-        # the plugin_dialog fixture has this id
-        # skip for 'constructor' variant
-        pytest.skip()
+        pytest.skip(reason="Tested functionality not available in constructor-based installs")
     assert plugin_dialog.direct_entry_edit.isVisible()
     assert plugin_dialog.direct_entry_btn.isVisible()
 
 
-def test_version_dropdown(qtbot, plugin_dialog):
+def test_version_dropdown(plugin_dialog):
     """
     Test that when the source drop down is changed, it displays the other versions properly.
     """

--- a/napari_plugin_manager/_tests/test_qt_plugin_dialog.py
+++ b/napari_plugin_manager/_tests/test_qt_plugin_dialog.py
@@ -177,6 +177,7 @@ def plugin_dialog(
     monkeypatch.setattr(
         qt_plugin_dialog, "running_as_constructor_app", lambda: request.param
     )
+    monkeypatch.setattr(qt_plugin_dialog, "ON_BUNDLE", request.param)
 
     monkeypatch.setattr(
         napari.plugins, 'plugin_manager', OldPluginManagerMock()
@@ -201,7 +202,7 @@ def plugin_dialog(
     assert not widget._add_items_timer.isActive()
 
 
-def test_filter_not_available_plugins(plugin_dialog):
+def test_filter_not_available_plugins(request, plugin_dialog):
     """
     Check that the plugins listed under available plugins are
     enabled and disabled accordingly.
@@ -212,6 +213,10 @@ def test_filter_not_available_plugins(plugin_dialog):
     The second plugin ("test-name-1") is available on conda-forge and
     should be enabled without the tooltip warning.
     """
+    if "no-constructor" not in request.node.name:
+        # the plugin_dialog fixture has this id
+        # skip for 'constructor' variant
+        pytest.skip()
     item = plugin_dialog.available_list.item(0)
     widget = plugin_dialog.available_list.itemWidget(item)
     if widget:

--- a/napari_plugin_manager/qt_plugin_dialog.py
+++ b/napari_plugin_manager/qt_plugin_dialog.py
@@ -1040,7 +1040,9 @@ class QtPluginDialog(QDialog):
         data = self._plugin_data.pop(0)
         project_info, is_available_in_conda, extra_info = data
         if project_info.name in self.already_installed:
-            self.installed_list.tag_outdated(project_info, is_available_in_conda)
+            self.installed_list.tag_outdated(
+                project_info, is_available_in_conda
+            )
         else:
             if project_info.name not in self.available_set:
                 self.available_set.add(project_info.name)

--- a/napari_plugin_manager/qt_plugin_dialog.py
+++ b/napari_plugin_manager/qt_plugin_dialog.py
@@ -57,6 +57,7 @@ SCALE = 1.6
 
 CONDA = 'Conda'
 PYPI = 'PyPI'
+ON_BUNDLE = running_as_constructor_app()
 
 
 def is_conda_package(pkg: str):
@@ -1037,9 +1038,9 @@ class QtPluginDialog(QDialog):
             return
 
         data = self._plugin_data.pop(0)
-        project_info, is_available, extra_info = data
+        project_info, is_available_in_conda, extra_info = data
         if project_info.name in self.already_installed:
-            self.installed_list.tag_outdated(project_info, is_available)
+            self.installed_list.tag_outdated(project_info, is_available_in_conda)
         else:
             if project_info.name not in self.available_set:
                 self.available_set.add(project_info.name)
@@ -1050,7 +1051,7 @@ class QtPluginDialog(QDialog):
                         extra_info['conda_versions'],
                     )
                 )
-            if not is_available:
+            if ON_BUNDLE and not is_available_in_conda:
                 self.available_list.tag_unavailable(project_info)
 
         self.filter()


### PR DESCRIPTION
Closes #7 

cc @Czaki 