### PR TITLE
Move conda util to utils module and clean up code

### DIFF
--- a/napari_plugin_manager/_tests/test_utils.py
+++ b/napari_plugin_manager/_tests/test_utils.py
@@ -1,0 +1,27 @@
+import sys
+from unittest.mock import patch
+
+import pytest
+
+from napari_plugin_manager.utils import is_conda_package
+
+
+@pytest.mark.parametrize(
+    "pkg_name,expected",
+    [
+        ("some-package", True),
+        ("some-other-package", False),
+        ("some-package-other", False),
+        ("other-some-package", False),
+        ("package", False),
+        ("some", False),
+    ],
+)
+def test_is_conda_package(pkg_name, expected, tmp_path):
+    mocked_conda_meta = tmp_path / 'conda-meta'
+    mocked_conda_meta.mkdir()
+    mocked_package = mocked_conda_meta / 'some-package-0.1.1-0.json'
+    mocked_package.touch()
+
+    with patch.object(sys, 'prefix', tmp_path):
+        assert is_conda_package(pkg_name) is expected

--- a/napari_plugin_manager/qt_plugin_dialog.py
+++ b/napari_plugin_manager/qt_plugin_dialog.py
@@ -1,7 +1,5 @@
 import importlib.metadata
 import os
-import re
-import sys
 from enum import Enum, auto
 from functools import partial
 from pathlib import Path
@@ -49,6 +47,7 @@ from napari_plugin_manager.qt_package_installer import (
     InstallerQueue,
     InstallerTools,
 )
+from napari_plugin_manager.utils import is_conda_package
 
 # TODO: add error icon and handle pip install errors
 
@@ -58,25 +57,7 @@ SCALE = 1.6
 CONDA = 'Conda'
 PYPI = 'PyPI'
 ON_BUNDLE = running_as_constructor_app()
-
-
-def is_conda_package(pkg: str):
-    """Determines if plugin was installed through conda.
-
-    Returns
-    -------
-    bool: True if a conda package, False if not
-    """
-
-    # Installed conda packages within a conda installation and environment can be identified as files
-    # with the template `<package-name>-<version>-<build-string>.json` saved within a `conda-meta` folder within
-    # the given environment of interest.
-
-    conda_meta_dir = Path(sys.prefix) / 'conda-meta'
-    return any(
-        re.match(rf"{pkg}-[^-]+-[^-]+.json", p.name)
-        for p in conda_meta_dir.glob(f"{pkg}-*-*.json")
-    )
+IS_NAPARI_CONDA_INSTALLED = is_conda_package('napari')
 
 
 class PluginListItem(QFrame):
@@ -327,10 +308,10 @@ class PluginListItem(QFrame):
         self.version_choice_text = QLabel('Version:')
         self.source_choice_dropdown = QComboBox()
 
-        if len(self._versions_pypi) is not None:
+        if self._versions_pypi:
             self.source_choice_dropdown.addItem(PYPI)
 
-        if len(self._versions_conda) is not None:
+        if IS_NAPARI_CONDA_INSTALLED and self._versions_conda:
             self.source_choice_dropdown.addItem(CONDA)
 
         self.source_choice_dropdown.currentTextChanged.connect(

--- a/napari_plugin_manager/utils.py
+++ b/napari_plugin_manager/utils.py
@@ -3,7 +3,7 @@ import sys
 from pathlib import Path
 
 
-def is_conda_package(pkg: str):
+def is_conda_package(pkg: str) -> bool:
     """Determines if plugin was installed through conda.
 
     Returns

--- a/napari_plugin_manager/utils.py
+++ b/napari_plugin_manager/utils.py
@@ -1,0 +1,21 @@
+import re
+import sys
+from pathlib import Path
+
+
+def is_conda_package(pkg: str):
+    """Determines if plugin was installed through conda.
+
+    Returns
+    -------
+    bool
+        ``True` if a conda package, ``False`` if not.
+    """
+    # Installed conda packages within a conda installation and environment can
+    # be identified as files with the template ``<package-name>-<version>-<build-string>.json``
+    # saved within a ``conda-meta`` folder within the given environment of interest.
+    conda_meta_dir = Path(sys.prefix) / 'conda-meta'
+    return any(
+        re.match(rf"{pkg}-[^-]+-[^-]+.json", p.name)
+        for p in conda_meta_dir.glob(f"{pkg}-*-*.json")
+    )


### PR DESCRIPTION
# Description
<!-- What does this pull request (PR) do? Why is it necessary? -->
<!-- Tell us about your new feature, improvement, or fix! -->
<!-- If your change includes user interface changes, please add an image, or an animation "An image is worth a thousand words!" -->
<!-- You can use https://www.cockos.com/licecap/ or similar to create animations -->

Replacement for https://github.com/napari/napari/pull/5641

Fixes #16
Fix not showing conda on dropdown for non conda installs

## Type of change
<!-- Please delete options that are not relevant. -->
- [x] Bug-fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# References
<!-- What resources, documentation, and guides were used in the creation of this PR? -->
<!-- If this is a bug-fix or otherwise resolves an issue, reference it here with "closes #(issue)" -->

Fixes https://github.com/napari/napari-plugin-manager/issues/16

# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [x] example: the test suite for my feature covers cases x, y, and z
- [x] example: all tests pass with my change
- [x] example: I check if my changes works with both PySide and PyQt backends
      as there are small differences between the two Qt bindings.  

## Final checklist:
- [x] My PR is the minimum possible work for the desired functionality
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] If I included new strings, I have used `trans.` to make them localizable.
      For more information see our [translations guide](https://napari.org/developers/translations.html).
