### PR TITLE
Change to use display name instead of package name

### DIFF
--- a/napari_plugin_manager/qt_plugin_dialog.py
+++ b/napari_plugin_manager/qt_plugin_dialog.py
@@ -99,9 +99,11 @@ class PluginListItem(QFrame):
         npe_version=1,
         versions_conda: List[str] = None,
         versions_pypi: List[str] = None,
+        display_name: str = '',
     ) -> None:
         super().__init__(parent)
         self.url = url
+        self.display_name = display_name or package_name
         self._versions_conda = versions_conda
         self._versions_pypi = versions_pypi
         self.setup_ui(enabled)


### PR DESCRIPTION
Part of https://github.com/napari/napari-plugin-manager/issues/14
Use display name instead of package name.