### PR TITLE
Add some small improvements to make the list load a bitfaster

### DIFF
--- a/napari_plugin_manager/_tests/test_qt_plugin_dialog.py
+++ b/napari_plugin_manager/_tests/test_qt_plugin_dialog.py
@@ -239,14 +239,14 @@ def test_filter_available_plugins(plugin_dialog):
     """
     plugin_dialog.filter("")
     assert plugin_dialog.available_list.count() == 2
-    assert plugin_dialog.available_list._count_visible() == 2
+    assert plugin_dialog.available_list.count_visible() == 2
 
     plugin_dialog.filter("no-match@123")
-    assert plugin_dialog.available_list._count_visible() == 0
+    assert plugin_dialog.available_list.count_visible() == 0
 
     plugin_dialog.filter("")
     plugin_dialog.filter("test-name-0")
-    assert plugin_dialog.available_list._count_visible() == 1
+    assert plugin_dialog.available_list.count_visible() == 1
 
 
 def test_filter_installed_plugins(plugin_dialog):
@@ -255,10 +255,10 @@ def test_filter_installed_plugins(plugin_dialog):
     list (the top one).
     """
     plugin_dialog.filter("")
-    assert plugin_dialog.installed_list._count_visible() >= 0
+    assert plugin_dialog.installed_list.count_visible() >= 0
 
     plugin_dialog.filter("no-match@123")
-    assert plugin_dialog.installed_list._count_visible() == 0
+    assert plugin_dialog.installed_list.count_visible() == 0
 
 
 def test_visible_widgets(request, plugin_dialog):
@@ -285,7 +285,7 @@ def test_version_dropdown(plugin_dialog):
 
 
 def test_plugin_list_count_items(plugin_dialog):
-    assert plugin_dialog.installed_list._count_visible() == 2
+    assert plugin_dialog.installed_list.count_visible() == 2
 
 
 def test_plugin_list_handle_action(plugin_dialog, qtbot):

--- a/napari_plugin_manager/qt_plugin_dialog.py
+++ b/napari_plugin_manager/qt_plugin_dialog.py
@@ -996,9 +996,10 @@ class QtPluginDialog(QDialog):
         """Counts all available but not installed plugins. Updates value."""
         all_count = len(self.all_plugin_data) - self.installed_list.count()
         count = self.available_list.count()
-        self.avail_label.setText(
-            trans._("Available Plugins ({count}/{all_count})", count=count, all_count=all_count)
-        )
+        if len(self.all_plugin_data) != 0 and all_count >= 0:
+            self.avail_label.setText(
+                trans._("Available Plugins ({count}/{all_count})", count=count, all_count=all_count)
+            )
 
     def _end_refresh(self):
         refresh_state = self.refresh_state

--- a/napari_plugin_manager/qt_plugin_dialog.py
+++ b/napari_plugin_manager/qt_plugin_dialog.py
@@ -998,7 +998,11 @@ class QtPluginDialog(QDialog):
         count = self.available_list.count()
         if len(self.all_plugin_data) != 0 and all_count >= 0:
             self.avail_label.setText(
-                trans._("Available Plugins ({count}/{all_count})", count=count, all_count=all_count)
+                trans._(
+                    "Available Plugins ({count}/{all_count})",
+                    count=count,
+                    all_count=all_count,
+                )
             )
 
     def _end_refresh(self):

--- a/napari_plugin_manager/qt_plugin_dialog.py
+++ b/napari_plugin_manager/qt_plugin_dialog.py
@@ -731,7 +731,7 @@ class QtPluginDialog(QDialog):
         self._filter_texts = []
         self._filter_idxs_cache = set()
         self._filter_timer = QTimer(self)
-	# timer to avoid triggering a filter for every keystroke
+        # timer to avoid triggering a filter for every keystroke
         self._filter_timer.setInterval(120)  # ms
         self._filter_timer.timeout.connect(self.filter)
         self._filter_timer.setSingleShot(True)

--- a/napari_plugin_manager/qt_plugin_dialog.py
+++ b/napari_plugin_manager/qt_plugin_dialog.py
@@ -1074,12 +1074,6 @@ class QtPluginDialog(QDialog):
             display_name = extra_info.get('display_name', metadata.name)
             if metadata.name in self.already_installed:
                 self.installed_list.tag_outdated(metadata, is_available_in_conda)
-
-            project_info, is_available_in_conda, extra_info = data
-            if project_info.name in self.already_installed:
-                self.installed_list.tag_outdated(
-                    project_info, is_available_in_conda
-                )
             else:
                 if metadata.name not in self.available_set:
                     self.available_set.add(metadata.name)
@@ -1115,7 +1109,7 @@ class QtPluginDialog(QDialog):
             for i in self.all_plugin_data
         ]
 
-    def search(self, text):
+    def _search(self, text):
         idxs = []
         for idx, item in enumerate(self.filter_texts):
             if text.lower() in item and idx not in self._filter_idxs_cache:
@@ -1135,7 +1129,7 @@ class QtPluginDialog(QDialog):
 
         # TODO: This is a workaround for the fact that the available list
         if not skip and self.available_list.is_running() and len(text) >= 1:
-            items = [self.all_plugin_data[idx] for idx in self.search(text)]
+            items = [self.all_plugin_data[idx] for idx in self._search(text)]
             if items:
                 self._add_items(items)
 

--- a/napari_plugin_manager/qt_plugin_dialog.py
+++ b/napari_plugin_manager/qt_plugin_dialog.py
@@ -687,15 +687,17 @@ class QPluginList(QListWidget):
             widget.action_button.setEnabled(False)
             widget.warning_tooltip.setVisible(True)
 
-    def filter(self, text: str):
+    def filter(self, text: str, starts_with_chars: int = 1):
         """Filter items to those containing `text`."""
         if text:
             # PySide has some issues, so we compare using id
             # See: https://bugreports.qt.io/browse/PYSIDE-74
-            shown = [
-                id(it)
-                for it in self.findItems(text, Qt.MatchFlag.MatchContains)
-            ]
+            flag = (
+                Qt.MatchFlag.MatchStartsWith
+                if len(text) <= starts_with_chars
+                else Qt.MatchFlag.MatchContains
+            )
+            shown = [id(it) for it in self.findItems(text, flag)]
             for i in range(self.count()):
                 item = self.item(i)
                 item.setHidden(id(item) not in shown)

--- a/napari_plugin_manager/qt_plugin_dialog.py
+++ b/napari_plugin_manager/qt_plugin_dialog.py
@@ -731,6 +731,7 @@ class QtPluginDialog(QDialog):
         self._filter_texts = []
         self._filter_idxs_cache = set()
         self._filter_timer = QTimer(self)
+	# timer to avoid triggering a filter for every keystroke
         self._filter_timer.setInterval(120)  # ms
         self._filter_timer.timeout.connect(self.filter)
         self._filter_timer.setSingleShot(True)
@@ -914,7 +915,6 @@ class QtPluginDialog(QDialog):
         self.packages_filter.setPlaceholderText(trans._("filter..."))
         self.packages_filter.setMaximumWidth(350)
         self.packages_filter.setClearButtonEnabled(True)
-        # Throttle keystrokes so only one filter is done every 200ms
         self.packages_filter.textChanged.connect(self._filter_timer.start)
         mid_layout = QVBoxLayout()
         mid_layout.addWidget(self.packages_filter)

--- a/napari_plugin_manager/qt_plugin_dialog.py
+++ b/napari_plugin_manager/qt_plugin_dialog.py
@@ -1105,7 +1105,7 @@ class QtPluginDialog(QDialog):
         self.all_plugin_data.append(data)
         self.available_list.set_data(self.all_plugin_data)
         self.filter_texts = [
-            f"{i[0].name} {i[-1]['display_name']} {i[0].summary}".lower()
+            f"{i[0].name} {i[-1].get('display_name', '')} {i[0].summary}".lower()
             for i in self.all_plugin_data
         ]
 

--- a/napari_plugin_manager/qt_plugin_dialog.py
+++ b/napari_plugin_manager/qt_plugin_dialog.py
@@ -19,7 +19,7 @@ from napari.utils.misc import (
     running_as_constructor_app,
 )
 from napari.utils.translations import trans
-from qtpy.QtCore import QEvent, QPoint, QSize, Qt, QTimer, Signal, Slot
+from qtpy.QtCore import QEvent, QPoint, QSize, Qt, QTimer, Slot
 from qtpy.QtGui import QFont, QMovie
 from qtpy.QtWidgets import (
     QCheckBox,
@@ -428,8 +428,6 @@ class PluginListItem(QFrame):
 
 class QPluginList(QListWidget):
 
-    filtered = Signal(int)
-
     def __init__(self, parent: QWidget, installer: InstallerQueue) -> None:
         super().__init__(parent)
         self.installer = installer
@@ -701,8 +699,6 @@ class QPluginList(QListWidget):
             for i in range(self.count()):
                 item = self.item(i)
                 item.setHidden(id(item) not in shown)
-
-            self.filtered.emit(shown)
         else:
             for i in range(self.count()):
                 item = self.item(i)

--- a/napari_plugin_manager/qt_plugin_dialog.py
+++ b/napari_plugin_manager/qt_plugin_dialog.py
@@ -698,6 +698,12 @@ class QPluginList(QListWidget):
                 else Qt.MatchFlag.MatchContains
             )
             shown = [id(it) for it in self.findItems(text, flag)]
+            if len(text) <= starts_with_chars:
+                text2 = f'napari-{text}'
+                shown = set(
+                    [id(it) for it in self.findItems(text2, flag)] + shown
+                )
+
             for i in range(self.count()):
                 item = self.item(i)
                 item.setHidden(id(item) not in shown)


### PR DESCRIPTION
Add small improvement on perceived speed of loading:

- Use batches of 2 (bigger batches start making the UI block on my machine)
- Use 62 ms between batches
- Allow for searching of plugins not yet on list, and add them
- throttle filter keystrokes so a filter starts only after some miliseconds
- add (X/N) to both list when filtering so it is clear that X plugins are filtered out of a total of N
- Change search type based on search text length, so if only `start_with_char` or less chars are typed then we match with starting letters only, otherwise we see if the text is contained in name/description etc. We also search for plugins that start with `napari-` plus the number of characters defined by `start_with_char` 

<img width="1062" alt="Screenshot 2024-05-29 at 11 48 50 AM" src="https://github.com/napari/napari-plugin-manager/assets/3627835/0c2baf90-9e0b-4e89-be7a-e93f4c3c97aa">
