### PR TITLE
Do not destroy plugin dialog on close, just hide it

### DIFF
--- a/napari_plugin_manager/npe2api.py
+++ b/napari_plugin_manager/npe2api.py
@@ -66,6 +66,7 @@ class SummaryDict(_ShortSummaryDict):
     conda_versions: NotRequired[list[str]]
 
 
+@lru_cache
 def plugin_summaries() -> list[SummaryDict]:
     """Return PackageMetadata object for all known napari plugins."""
     url = 'https://npe2api.vercel.app/api/extended_summary'

--- a/napari_plugin_manager/qt_plugin_dialog.py
+++ b/napari_plugin_manager/qt_plugin_dialog.py
@@ -699,7 +699,10 @@ class QtPluginDialog(QDialog):
         super().__init__(parent)
 
         self._parent = parent
-        if getattr(parent, '_plugin_dialog', None) is None:
+        if (
+            getattr(parent, '_plugin_dialog', None) is None
+            and self._parent is not None
+        ):
             self._parent._plugin_dialog = self
 
         self.refresh_state = RefreshState.DONE
@@ -751,14 +754,17 @@ class QtPluginDialog(QDialog):
             self.close()
 
     def closeEvent(self, event):
-        plugin_dialog = getattr(self._parent, '_plugin_dialog', self)
-        if plugin_dialog != self:
-            self._add_items_timer.stop()
-            if self.close_btn.isEnabled():
-                super().closeEvent(event)
-            event.ignore()
+        if self._parent is not None:
+            plugin_dialog = getattr(self._parent, '_plugin_dialog', self)
+            if plugin_dialog != self:
+                self._add_items_timer.stop()
+                if self.close_btn.isEnabled():
+                    super().closeEvent(event)
+                event.ignore()
+            else:
+                plugin_dialog.hide()
         else:
-            plugin_dialog.hide()
+            super().closeEvent(event)
 
     def refresh(self):
         if self.refresh_state != RefreshState.DONE:

--- a/napari_plugin_manager/qt_plugin_dialog.py
+++ b/napari_plugin_manager/qt_plugin_dialog.py
@@ -697,6 +697,11 @@ class RefreshState(Enum):
 class QtPluginDialog(QDialog):
     def __init__(self, parent=None) -> None:
         super().__init__(parent)
+
+        self._parent = parent
+        if getattr(parent, '_plugin_dialog', None) is None:
+            self._parent._plugin_dialog = self
+
         self.refresh_state = RefreshState.DONE
         self.already_installed = set()
         self.available_set = set()
@@ -737,11 +742,23 @@ class QtPluginDialog(QDialog):
         self.close_btn.setDisabled(False)
         self.refresh()
 
+    def exec_(self):
+        plugin_dialog = getattr(self._parent, '_plugin_dialog', self)
+        plugin_dialog.setModal(True)
+        plugin_dialog.show()
+
+        if plugin_dialog != self:
+            self.close()
+
     def closeEvent(self, event):
-        self._add_items_timer.stop()
-        if self.close_btn.isEnabled():
-            super().closeEvent(event)
-        event.ignore()
+        plugin_dialog = getattr(self._parent, '_plugin_dialog', self)
+        if plugin_dialog != self:
+            self._add_items_timer.stop()
+            if self.close_btn.isEnabled():
+                super().closeEvent(event)
+            event.ignore()
+        else:
+            plugin_dialog.hide()
 
     def refresh(self):
         if self.refresh_state != RefreshState.DONE:


### PR DESCRIPTION
This is handling the plugin dialog from this side, but maybe it would be better to handle it on the napari side, to avoid the creation of a duplicate dialog for some seconds. 

I will open a PR on the napari side https://github.com/napari/napari/blob/f3b00c0936caaa87814e8c9b0497f20008d057e1/napari/_qt/_qapp_model/qactions/_plugins.py#L35C20-L35C37

To only create the dialog once. This however serves as POC so you can test how it works!

See how the counter keeps running between open and closing and how it remains on 406 after open and closing once it has finished.

![napari-dialog](https://github.com/napari/napari-plugin-manager/assets/3627835/9bf0ea3f-6942-4b17-b489-50f947743ee0)


