### PR TITLE
Search for plugins to install on demand

### DIFF
--- a/napari_plugin_manager/_tests/test_npe2api.py
+++ b/napari_plugin_manager/_tests/test_npe2api.py
@@ -13,7 +13,7 @@ def test_user_agent():
     assert _user_agent()
 
 
-@flaky(max_runs=3, min_passes=2)
+@flaky(max_runs=4, min_passes=2)
 def test_plugin_summaries():
     keys = [
         "name",

--- a/napari_plugin_manager/npe2api.py
+++ b/napari_plugin_manager/npe2api.py
@@ -88,7 +88,6 @@ def iter_napari_plugin_info() -> Iterator[tuple[PackageMetadata, bool, dict]]:
         with ThreadPoolExecutor() as executor:
             data = executor.submit(plugin_summaries)
             _conda = executor.submit(conda_map)
-
         conda = _conda.result()
         data_set = data.result()
     except (HTTPError, URLError):

--- a/napari_plugin_manager/qt_plugin_dialog.py
+++ b/napari_plugin_manager/qt_plugin_dialog.py
@@ -1148,7 +1148,9 @@ class QtPluginDialog(QDialog):
         lay.setContentsMargins(0, 2, 0, 2)
         self.installed_label = QLabel(trans._("Installed Plugins"))
         self.packages_search = QLineEdit()
-        self.packages_search.setPlaceholderText(trans._("search..."))
+        self.packages_search.setPlaceholderText(trans._("Type here to start searching for plugins..."))
+        self.packages_search.setToolTip(trans._("The search text will filter currently installed plugins "
+                                                "while also being used to search for plugins on the napari hub"))
         self.packages_search.setMaximumWidth(350)
         self.packages_search.setClearButtonEnabled(True)
         self.packages_search.textChanged.connect(self.search)

--- a/napari_plugin_manager/qt_plugin_dialog.py
+++ b/napari_plugin_manager/qt_plugin_dialog.py
@@ -865,7 +865,7 @@ class QPluginList(QListWidget):
 
 
 class QtPluginDialog(QDialog):
-    MAX_PLUGIN_SEARCH_ITEMS = 20
+    MAX_PLUGIN_SEARCH_ITEMS = 35
 
     finished = Signal()
 
@@ -882,7 +882,6 @@ class QtPluginDialog(QDialog):
         self._plugins_found = 0
         self.already_installed = set()
         self.available_set = set()
-        self._max_search_items = 20
         self._prefix = prefix
         self._first_open = True
         self._plugin_queue = []  # Store plugin data to be added

--- a/napari_plugin_manager/qt_plugin_dialog.py
+++ b/napari_plugin_manager/qt_plugin_dialog.py
@@ -1148,9 +1148,15 @@ class QtPluginDialog(QDialog):
         lay.setContentsMargins(0, 2, 0, 2)
         self.installed_label = QLabel(trans._("Installed Plugins"))
         self.packages_search = QLineEdit()
-        self.packages_search.setPlaceholderText(trans._("Type here to start searching for plugins..."))
-        self.packages_search.setToolTip(trans._("The search text will filter currently installed plugins "
-                                                "while also being used to search for plugins on the napari hub"))
+        self.packages_search.setPlaceholderText(
+            trans._("Type here to start searching for plugins...")
+        )
+        self.packages_search.setToolTip(
+            trans._(
+                "The search text will filter currently installed plugins "
+                "while also being used to search for plugins on the napari hub"
+            )
+        )
         self.packages_search.setMaximumWidth(350)
         self.packages_search.setClearButtonEnabled(True)
         self.packages_search.textChanged.connect(self.search)

--- a/napari_plugin_manager/qt_plugin_dialog.py
+++ b/napari_plugin_manager/qt_plugin_dialog.py
@@ -1127,6 +1127,7 @@ class QtPluginDialog(QDialog):
         self.worker.started.connect(self.working_indicator.show)
         self.worker.finished.connect(self.working_indicator.hide)
         self.worker.finished.connect(self.finished)
+        self.worker.finished.connect(self.search)
         self.worker.start()
 
         pm2 = npe2.PluginManager.instance()

--- a/napari_plugin_manager/qt_plugin_dialog.py
+++ b/napari_plugin_manager/qt_plugin_dialog.py
@@ -1317,7 +1317,7 @@ class QtPluginDialog(QDialog):
         if self._plugins_found == 0:
             self.avail_label.setText(
                 trans._(
-                    "{amount} plugins available in the napari Hub",
+                    "{amount} plugins available on the napari hub",
                     found=self._plugins_found,
                     amount=available_count,
                 )
@@ -1325,7 +1325,7 @@ class QtPluginDialog(QDialog):
         elif self._plugins_found > self.MAX_PLUGIN_SEARCH_ITEMS:
             self.avail_label.setText(
                 trans._(
-                    "Found ({found}) out of {amount} in the napari Hub. Displaying the first {max_count} plugins...",
+                    "Found {found) out of {amount} plugins on the napari hub. Displaying the first {max_count}...",
                     found=self._plugins_found,
                     amount=available_count,
                     max_count=self.MAX_PLUGIN_SEARCH_ITEMS,
@@ -1334,7 +1334,7 @@ class QtPluginDialog(QDialog):
         else:
             self.avail_label.setText(
                 trans._(
-                    "Found ({found}) out of {amount} in the napari Hub",
+                    "Found {found} out of {amount} plugins on the napari hub",
                     found=self._plugins_found,
                     amount=available_count,
                 )

--- a/napari_plugin_manager/qt_plugin_dialog.py
+++ b/napari_plugin_manager/qt_plugin_dialog.py
@@ -1325,7 +1325,7 @@ class QtPluginDialog(QDialog):
         elif self._plugins_found > self.MAX_PLUGIN_SEARCH_ITEMS:
             self.avail_label.setText(
                 trans._(
-                    "Found {found) out of {amount} plugins on the napari hub. Displaying the first {max_count}...",
+                    "Found {found} out of {amount} plugins on the napari hub. Displaying the first {max_count}...",
                     found=self._plugins_found,
                     amount=available_count,
                     max_count=self.MAX_PLUGIN_SEARCH_ITEMS,


### PR DESCRIPTION
Fixes https://github.com/napari/napari-plugin-manager/issues/83
Fixes #76 

As discussed in https://github.com/napari/napari-plugin-manager/issues/37 as more and more plugins are added to the ecosystem loading a big list of plugins might become unsustainable, specially if we keep using complex custom and styles widgets within the `Qlistwidgetitems`.

Another approach to this, that could still preserve the rich styling of widgets is to only display the items after a search, that way we only populate the list on demand if a user is looking for something. This is what other tools like VSCode handle it. Added a small preview, of course this would require some styling, but this work fits nicely into what has already been provided by the latest PRs

![napari-dialog](https://github.com/napari/napari-plugin-manager/assets/3627835/808a7296-3004-4de9-b2e6-51fcc866d9b0)
