### PR TITLE
Add shortcut to close plugin manager dialog and quit application

### DIFF
--- a/napari_plugin_manager/_tests/test_qt_plugin_dialog.py
+++ b/napari_plugin_manager/_tests/test_qt_plugin_dialog.py
@@ -383,9 +383,6 @@ def test_add_items_outdated(plugin_dialog):
     assert widget.update_btn.isVisible()
 
 
-@pytest.mark.skipif(
-    platform.system() != "Darwin", reason="shortcut only on mac systems"
-)
 def test_shortcut_close(plugin_dialog, qtbot):
     qtbot.keyClicks(
         plugin_dialog, 'W', modifier=Qt.KeyboardModifier.ControlModifier

--- a/napari_plugin_manager/_tests/test_qt_plugin_dialog.py
+++ b/napari_plugin_manager/_tests/test_qt_plugin_dialog.py
@@ -10,6 +10,7 @@ import pytest
 import qtpy
 from napari.plugins._tests.test_npe2 import mock_pm  # noqa
 from napari.utils.translations import trans
+from qtpy.QtCore import Qt
 
 if (qtpy.API_NAME == 'PySide2' and platform.system() != "Linux") or (
     sys.version_info[:2] > (3, 10) and platform.system() == "Linux"
@@ -380,3 +381,22 @@ def test_add_items_outdated(plugin_dialog):
     widget = plugin_dialog.installed_list.itemWidget(item)
 
     assert widget.update_btn.isVisible()
+
+
+@pytest.mark.skipif(
+    platform.system() != "Darwin", reason="shortcut only on mac systems"
+)
+def test_shortcut_close(plugin_dialog, qtbot):
+    qtbot.keyClicks(
+        plugin_dialog, 'W', modifier=Qt.KeyboardModifier.ControlModifier
+    )
+    qtbot.wait(200)
+    assert not plugin_dialog.isVisible()
+
+
+def test_shortcut_quit(plugin_dialog, qtbot):
+    qtbot.keyClicks(
+        plugin_dialog, 'Q', modifier=Qt.KeyboardModifier.ControlModifier
+    )
+    qtbot.wait(200)
+    assert not plugin_dialog.isVisible()

--- a/napari_plugin_manager/qt_plugin_dialog.py
+++ b/napari_plugin_manager/qt_plugin_dialog.py
@@ -21,7 +21,7 @@ from napari.utils.misc import (
 )
 from napari.utils.translations import trans
 from qtpy.QtCore import QEvent, QPoint, QSize, Qt, QTimer, Slot
-from qtpy.QtGui import QFont, QKeySequence, QMovie, QShortcut
+from qtpy.QtGui import QAction, QFont, QKeySequence, QMovie, QShortcut
 from qtpy.QtWidgets import (
     QCheckBox,
     QComboBox,
@@ -782,6 +782,19 @@ class QtPluginDialog(QDialog):
             or parent is None
         ):
             self.refresh()
+            self._setup_shortcuts()
+
+    def _quit(self):
+        self.close()
+        self._parent.close(quit_app=True)
+
+    def _setup_shortcuts(self):
+        if self._parent is not None:
+            self._quit_action = QAction(trans._('Exit'), self)
+            self._quit_action.setShortcut('Ctrl+Q')
+            self._quit_action.setMenuRole(QAction.QuitRole)
+            self._quit_action.triggered.connect(self._quit)
+            self.addAction(self._quit_action)
 
         if platform.system() == "Darwin":
             self._close_shortcut = QShortcut(

--- a/napari_plugin_manager/qt_plugin_dialog.py
+++ b/napari_plugin_manager/qt_plugin_dialog.py
@@ -1,5 +1,6 @@
 import importlib.metadata
 import os
+import platform
 from enum import Enum, auto
 from functools import partial
 from pathlib import Path
@@ -20,7 +21,7 @@ from napari.utils.misc import (
 )
 from napari.utils.translations import trans
 from qtpy.QtCore import QEvent, QPoint, QSize, Qt, QTimer, Slot
-from qtpy.QtGui import QFont, QMovie
+from qtpy.QtGui import QFont, QKeySequence, QMovie, QShortcut
 from qtpy.QtWidgets import (
     QCheckBox,
     QComboBox,
@@ -781,6 +782,12 @@ class QtPluginDialog(QDialog):
             or parent is None
         ):
             self.refresh()
+
+        if platform.system() == "Darwin":
+            self._close_shortcut = QShortcut(
+                QKeySequence(Qt.CTRL | Qt.Key_W), self
+            )
+            self._close_shortcut.activated.connect(self.close)
 
     def _on_installer_start(self):
         """Updates dialog buttons and status when installing a plugin."""

--- a/napari_plugin_manager/qt_plugin_dialog.py
+++ b/napari_plugin_manager/qt_plugin_dialog.py
@@ -797,11 +797,10 @@ class QtPluginDialog(QDialog):
         self._quit_action.triggered.connect(self._quit)
         self.addAction(self._quit_action)
 
-        if platform.system() == "Darwin":
-            self._close_shortcut = QShortcut(
-                QKeySequence(Qt.CTRL | Qt.Key_W), self
-            )
-            self._close_shortcut.activated.connect(self.close)
+        self._close_shortcut = QShortcut(
+            QKeySequence(Qt.CTRL | Qt.Key_W), self
+        )
+        self._close_shortcut.activated.connect(self.close)
 
     def _on_installer_start(self):
         """Updates dialog buttons and status when installing a plugin."""

--- a/napari_plugin_manager/qt_plugin_dialog.py
+++ b/napari_plugin_manager/qt_plugin_dialog.py
@@ -1,7 +1,6 @@
 import contextlib
 import importlib.metadata
 import os
-import platform
 from enum import Enum, auto
 from functools import partial
 from pathlib import Path

--- a/napari_plugin_manager/qt_plugin_dialog.py
+++ b/napari_plugin_manager/qt_plugin_dialog.py
@@ -788,7 +788,7 @@ class QtPluginDialog(QDialog):
     def _quit(self):
         self.close()
         with contextlib.suppress(AttributeError):
-            self._parent.close(quit_app=True)
+            self._parent.close(quit_app=True, confirm_need=True)
 
     def _setup_shortcuts(self):
         self._quit_action = QAction(trans._('Exit'), self)

--- a/napari_plugin_manager/qt_plugin_dialog.py
+++ b/napari_plugin_manager/qt_plugin_dialog.py
@@ -1,3 +1,4 @@
+import contextlib
 import importlib.metadata
 import os
 import platform
@@ -786,15 +787,15 @@ class QtPluginDialog(QDialog):
 
     def _quit(self):
         self.close()
-        self._parent.close(quit_app=True)
+        with contextlib.suppress(AttributeError):
+            self._parent.close(quit_app=True)
 
     def _setup_shortcuts(self):
-        if self._parent is not None:
-            self._quit_action = QAction(trans._('Exit'), self)
-            self._quit_action.setShortcut('Ctrl+Q')
-            self._quit_action.setMenuRole(QAction.QuitRole)
-            self._quit_action.triggered.connect(self._quit)
-            self.addAction(self._quit_action)
+        self._quit_action = QAction(trans._('Exit'), self)
+        self._quit_action.setShortcut('Ctrl+Q')
+        self._quit_action.setMenuRole(QAction.QuitRole)
+        self._quit_action.triggered.connect(self._quit)
+        self.addAction(self._quit_action)
 
         if platform.system() == "Darwin":
             self._close_shortcut = QShortcut(


### PR DESCRIPTION
Fixes #38
Fixes #4

Add shortcut to close plugin manager dialog on mac systems (Cmd+W) and quit application on all other systems (Ctrl+Q)