### PR TITLE
Fix constraint file creation and clean up logic on Windows

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -83,3 +83,7 @@ target/
 
 # ruff stuff
 .ruff_cache/
+
+# spyder stuff
+.spyproject/
+

--- a/napari_plugin_manager/qt_package_installer.py
+++ b/napari_plugin_manager/qt_package_installer.py
@@ -140,10 +140,9 @@ class PipInstallerTool(AbstractInstallerTool):
     @classmethod
     @lru_cache(maxsize=0)
     def _constraints_file(cls) -> str:
-        file_descriptor, path = mkstemp("-napari-constraints.txt", text=True)
-        with os.fdopen(file_descriptor, "w") as f:
+        with NamedTemporaryFile("-napari-constraints.txt", delete=False) as f:
             f.write("\n".join(cls.constraints()))
-        atexit.register(os.unlink, path)
+        atexit.register(os.unlink, f.name)
         return path
 
 

--- a/napari_plugin_manager/qt_package_installer.py
+++ b/napari_plugin_manager/qt_package_installer.py
@@ -20,7 +20,7 @@ from functools import lru_cache
 from logging import getLogger
 from pathlib import Path
 from subprocess import call
-from tempfile import gettempdir, mkstemp
+from tempfile import gettempdir
 from typing import Deque, Optional, Sequence, Tuple
 
 from napari._version import version as _napari_version

--- a/napari_plugin_manager/qt_package_installer.py
+++ b/napari_plugin_manager/qt_package_installer.py
@@ -140,8 +140,8 @@ class PipInstallerTool(AbstractInstallerTool):
     @classmethod
     @lru_cache(maxsize=0)
     def _constraints_file(cls) -> str:
-        _, path = mkstemp("-napari-constraints.txt", text=True)
-        with open(path, "w") as f:
+        file_descriptor, path = mkstemp("-napari-constraints.txt", text=True)
+        with os.fdopen(file_descriptor, "w") as f:
             f.write("\n".join(cls.constraints()))
         atexit.register(os.unlink, path)
         return path

--- a/napari_plugin_manager/qt_package_installer.py
+++ b/napari_plugin_manager/qt_package_installer.py
@@ -20,7 +20,7 @@ from functools import lru_cache
 from logging import getLogger
 from pathlib import Path
 from subprocess import call
-from tempfile import gettempdir
+from tempfile import NamedTemporaryFile, gettempdir
 from typing import Deque, Optional, Sequence, Tuple
 
 from napari._version import version as _napari_version
@@ -140,10 +140,12 @@ class PipInstallerTool(AbstractInstallerTool):
     @classmethod
     @lru_cache(maxsize=0)
     def _constraints_file(cls) -> str:
-        with NamedTemporaryFile("-napari-constraints.txt", delete=False) as f:
+        with NamedTemporaryFile(
+            "w", suffix="-napari-constraints.txt", delete=False
+        ) as f:
             f.write("\n".join(cls.constraints()))
         atexit.register(os.unlink, f.name)
-        return path
+        return f.name
 
 
 class CondaInstallerTool(AbstractInstallerTool):


### PR DESCRIPTION
Fix constraing file creation and clean up logic by using `tempfile.mkstemp` returned file descriptor to handle constraint file operations. The previous logic was ignoring the returned file descriptor and instead directly using `open` via the temporary file path and missing to close the ignored file descriptor

Fixes #63 

Edit: Move from using `tempfile.mkstemp` to `tempfile.NamedTemporaryFile`