### PR TITLE
Change base widget used to position install plugin pop up message/warning and delta

### DIFF
--- a/napari_plugin_manager/qt_plugin_dialog.py
+++ b/napari_plugin_manager/qt_plugin_dialog.py
@@ -924,10 +924,18 @@ class QtPluginDialog(QDialog):
                 'you must restart napari for UI changes to take effect.'
             )
             self._warn_dialog = WarnPopup(text=message)
-            global_point = self.close_btn.mapToGlobal(
-                self.close_btn.rect().topLeft()
+            global_point = self.installed_label.mapToGlobal(
+                self.installed_label.rect().topLeft()
             )
-            global_point = QPoint(global_point.x() - 50, global_point.y())
+            delta_text = (
+                5  # To have some space between the label text and the popup
+                + self.installed_label.fontMetrics()
+                .boundingRect(self.installed_label.text())
+                .width()
+            )
+            global_point = QPoint(
+                global_point.x() + delta_text, global_point.y()
+            )
             self._warn_dialog.move(global_point)
             self._warn_dialog.exec_()
 

--- a/napari_plugin_manager/qt_plugin_dialog.py
+++ b/napari_plugin_manager/qt_plugin_dialog.py
@@ -924,10 +924,10 @@ class QtPluginDialog(QDialog):
                 'you must restart napari for UI changes to take effect.'
             )
             self._warn_dialog = WarnPopup(text=message)
-            global_point = self.process_error_indicator.mapToGlobal(
-                self.process_error_indicator.rect().topLeft()
+            global_point = self.close_btn.mapToGlobal(
+                self.close_btn.rect().topLeft()
             )
-            global_point = QPoint(global_point.x(), global_point.y() - 75)
+            global_point = QPoint(global_point.x() - 50, global_point.y())
             self._warn_dialog.move(global_point)
             self._warn_dialog.exec_()
 


### PR DESCRIPTION
# References and relevant issues

Fixes #65

# Description

Checking the code related with the install plugin pop up positioning, seems like the logic was using the process error indicator widget (one of the labels used to show the actions state on the bottom rigth side of the dialog). Since this label is only shown when there is a code error when executing an installation, using it as the base one to get the position where the pop up should appear causes the pop up to end up using as base position the top left dialog when no error happens (since the label is hidden and its position gets mapped to that base point)

Following the above this PR changes the base widget used to get the base position where the pop up should be shown. Some exploration about what widget to use is being done:

|Option|Preview|
|-|-|
|Use the close button (which always is visible), and use a -50 delta to change the base coordinates to show the pop up along side the label showing the status of the actions (✔️  or ⚠️)|![install_plugin_popup](https://github.com/napari/napari-plugin-manager/assets/16781833/0c5a7be9-29dd-4dc6-86c3-346d0afd6d34)|
|**(Current PR state)** Use the installed plugins counter label using the label text width + 5 to calculate the initial position of the pop up|![347029289-f38c99fe-b555-48ae-8d97-113bbee2cb1e](https://github.com/napari/napari-plugin-manager/assets/16781833/519fe173-28c0-4ecc-bb1e-b0a263dac48b)|

# Notes

* Maybe is worthy to define a better place to put the popup?
   * For the moment use the installed plugins counter label as widget to get the base point where the pop up widget is placed
   * New issue (#69) created to explore better ways to show the information the pop up shows/actions state