### PR TITLE
Add toolbutton to select action from direct entry install

### DIFF
--- a/napari_plugin_manager/_tests/test_npe2api.py
+++ b/napari_plugin_manager/_tests/test_npe2api.py
@@ -1,3 +1,5 @@
+from flaky import flaky
+
 from napari_plugin_manager.npe2api import (
     _user_agent,
     cache_clear,
@@ -11,6 +13,7 @@ def test_user_agent():
     assert _user_agent()
 
 
+@flaky(max_runs=3, min_passes=2)
 def test_plugin_summaries():
     keys = [
         "name",

--- a/napari_plugin_manager/qt_plugin_dialog.py
+++ b/napari_plugin_manager/qt_plugin_dialog.py
@@ -1194,6 +1194,7 @@ class QtPluginDialog(QDialog):
         self.direct_entry_btn.clicked.connect(self._install_packages)
         self.direct_entry_btn.setText(trans._("Install"))
         self.direct_entry_btn.setToolButtonStyle(Qt.ToolButtonTextBesideIcon)
+        self.direct_entry_btn.setPopupMode(QToolButton.MenuButtonPopup)
 
         self._action_conda = QAction(trans._('Conda'), self)
         self._action_conda.setCheckable(True)

--- a/napari_plugin_manager/qt_plugin_dialog.py
+++ b/napari_plugin_manager/qt_plugin_dialog.py
@@ -923,6 +923,11 @@ class QtPluginDialog(QDialog):
             self._parent.close(quit_app=True, confirm_need=True)
 
     def _setup_shortcuts(self):
+        self._refresh_styles_action = QAction(trans._('Refresh Styles'), self)
+        self._refresh_styles_action.setShortcut('Ctrl+R')
+        self._refresh_styles_action.triggered.connect(self._update_theme)
+        self.addAction(self._refresh_styles_action)
+
         self._quit_action = QAction(trans._('Exit'), self)
         self._quit_action.setShortcut('Ctrl+Q')
         self._quit_action.setMenuRole(QAction.QuitRole)
@@ -1193,8 +1198,6 @@ class QtPluginDialog(QDialog):
         self.direct_entry_btn.setVisible(visibility_direct_entry)
         self.direct_entry_btn.clicked.connect(self._install_packages)
         self.direct_entry_btn.setText(trans._("Install"))
-        self.direct_entry_btn.setToolButtonStyle(Qt.ToolButtonTextBesideIcon)
-        self.direct_entry_btn.setPopupMode(QToolButton.MenuButtonPopup)
 
         self._action_conda = QAction(trans._('Conda'), self)
         self._action_conda.setCheckable(True)
@@ -1214,6 +1217,7 @@ class QtPluginDialog(QDialog):
         self._menu.addAction(self._action_pypi)
 
         if IS_NAPARI_CONDA_INSTALLED:
+            self.direct_entry_btn.setPopupMode(QToolButton.MenuButtonPopup)
             self._action_conda.setChecked(True)
             self.direct_entry_btn.setMenu(self._menu)
 

--- a/napari_plugin_manager/qt_plugin_dialog.py
+++ b/napari_plugin_manager/qt_plugin_dialog.py
@@ -23,7 +23,14 @@ from napari.utils.misc import (
 from napari.utils.notifications import show_info, show_warning
 from napari.utils.translations import trans
 from qtpy.QtCore import QPoint, QSize, Qt, QTimer, Signal, Slot
-from qtpy.QtGui import QAction, QFont, QKeySequence, QMovie, QShortcut
+from qtpy.QtGui import (
+    QAction,
+    QActionGroup,
+    QFont,
+    QKeySequence,
+    QMovie,
+    QShortcut,
+)
 from qtpy.QtWidgets import (
     QCheckBox,
     QComboBox,
@@ -35,10 +42,12 @@ from qtpy.QtWidgets import (
     QLineEdit,
     QListWidget,
     QListWidgetItem,
+    QMenu,
     QPushButton,
     QSizePolicy,
     QSplitter,
     QTextEdit,
+    QToolButton,
     QVBoxLayout,
     QWidget,
 )
@@ -1178,13 +1187,34 @@ class QtPluginDialog(QDialog):
         visibility_direct_entry = not running_as_constructor_app()
         self.direct_entry_edit = QLineEdit(self)
         self.direct_entry_edit.installEventFilter(self)
-        self.direct_entry_edit.setPlaceholderText(
-            trans._('install by name/url, or drop file...')
-        )
+        self.direct_entry_edit.returnPressed.connect(self._install_packages)
         self.direct_entry_edit.setVisible(visibility_direct_entry)
-        self.direct_entry_btn = QPushButton(trans._("Install"), self)
+        self.direct_entry_btn = QToolButton(self)
         self.direct_entry_btn.setVisible(visibility_direct_entry)
         self.direct_entry_btn.clicked.connect(self._install_packages)
+        self.direct_entry_btn.setText(trans._("Install"))
+        self.direct_entry_btn.setToolButtonStyle(Qt.ToolButtonTextBesideIcon)
+
+        self._action_conda = QAction(trans._('Conda'), self)
+        self._action_conda.setCheckable(True)
+        self._action_conda.triggered.connect(self._update_direct_entry_text)
+
+        self._action_pypi = QAction(trans._('pip'), self)
+        self._action_pypi.setCheckable(True)
+        self._action_pypi.triggered.connect(self._update_direct_entry_text)
+
+        self._action_group = QActionGroup(self)
+        self._action_group.addAction(self._action_pypi)
+        self._action_group.addAction(self._action_conda)
+        self._action_group.setExclusive(True)
+
+        self._menu = QMenu(self)
+        self._menu.addAction(self._action_conda)
+        self._menu.addAction(self._action_pypi)
+
+        if IS_NAPARI_CONDA_INSTALLED:
+            self._action_conda.setChecked(True)
+            self.direct_entry_btn.setMenu(self._menu)
 
         self.show_status_btn = QPushButton(trans._("Show Status"), self)
         self.show_status_btn.setFixedWidth(100)
@@ -1221,6 +1251,19 @@ class QtPluginDialog(QDialog):
         self.h_splitter.setStretchFactor(0, 2)
 
         self.packages_filter.setFocus()
+        self._update_direct_entry_text()
+
+    def _update_direct_entry_text(self):
+        tool = (
+            str(InstallerTools.CONDA)
+            if self._action_conda.isChecked()
+            else str(InstallerTools.PIP)
+        )
+        self.direct_entry_edit.setPlaceholderText(
+            trans._(
+                "install with '{tool}' by name/url, or drop file...", tool=tool
+            )
+        )
 
     def _update_plugin_count(self):
         """Update count labels for both installed and available plugin lists.
@@ -1275,7 +1318,12 @@ class QtPluginDialog(QDialog):
             self.direct_entry_edit.clear()
 
         if packages:
-            self.installer.install(InstallerTools.PIP, packages)
+            tool = (
+                InstallerTools.CONDA
+                if self._action_conda.isChecked()
+                else InstallerTools.PIP
+            )
+            self.installer.install(tool, packages)
 
     def _tag_outdated_plugins(self):
         """Tag installed plugins that might be outdated."""

--- a/napari_plugin_manager/styles.qss
+++ b/napari_plugin_manager/styles.qss
@@ -366,10 +366,10 @@ QToolButton:pressed {
   background-color: {{ lighten(foreground, 20) }}
 }
 
-QToolButton::menu-indicator { /* the arrow mark in the tool buttons */
+QToolButton::menu-arrow {
   image: url("theme_{{ id }}:/down_arrow.svg");
-  top: -2px;
-  left: -2px;
-  width: 10px;
-  height: 10px;
+  top: 0px;
+  left: 0px;
+  width: 5px;
+  height: 5px;
 }

--- a/napari_plugin_manager/styles.qss
+++ b/napari_plugin_manager/styles.qss
@@ -350,3 +350,26 @@ QtLayerList::indicator:checked {
   min-height: 36px;
   min-width: 36px;
 }
+
+QToolButton {
+  background-color: {{ darken(foreground, 20) }};
+  color: {{ darken(text, 15) }};
+  padding: 3 12px;
+  font: 14px;
+}
+
+QToolButton:hover {
+  background-color: {{ lighten(foreground, 10) }}
+}
+
+QToolButton:pressed {
+  background-color: {{ lighten(foreground, 20) }}
+}
+
+QToolButton::menu-indicator { /* the arrow mark in the tool buttons */
+  image: url("theme_{{ id }}:/down_arrow.svg");
+  top: -2px;
+  left: -2px;
+  width: 10px;
+  height: 10px;
+}

--- a/napari_plugin_manager/styles.qss
+++ b/napari_plugin_manager/styles.qss
@@ -370,6 +370,14 @@ QToolButton::menu-arrow {
   image: url("theme_{{ id }}:/down_arrow.svg");
   top: 0px;
   left: 0px;
-  width: 5px;
-  height: 5px;
+  width: 8px;
+  height: 8px;
+}
+
+QToolButton[popupMode="1"]{
+  padding-right: 20px;
+}
+
+QToolButton::menu-button {
+  width: 16px;
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,10 +63,11 @@ dev = [
 ]
 
 testing = [
+  "flaky",
   "pytest",
-  "virtualenv",
   "pytest-cov",
   "pytest-qt",
+  "virtualenv"
 ]
 
 docs = [


### PR DESCRIPTION
Fixes #84

![napari](https://github.com/user-attachments/assets/62e34da1-7771-49ef-a741-110656a23824)


Conda/pypi options are exclusive so selecting one, will leave that as the default.


To test locally this https://github.com/napari/napari-plugin-manager/pull/96/files#diff-c4a932d5522a5a713957223899c8991682affd18d838b197d3c508ea32333a1eR1215

might need a manual `if True` 