### PR TITLE
Don't use `StringEnum` subclasses over Qt Signal definition

### DIFF
--- a/napari_plugin_manager/_tests/test_qt_plugin_dialog.py
+++ b/napari_plugin_manager/_tests/test_qt_plugin_dialog.py
@@ -14,14 +14,13 @@ from napari.utils.translations import trans
 from qtpy.QtCore import QMimeData, QPointF, Qt, QUrl
 from qtpy.QtGui import QDropEvent
 
-# if (qtpy.API_NAME == 'PySide2') or (
-#     sys.version_info[:2] > (3, 10) and platform.system() == "Linux"
-# ):
-#     pytest.skip(
-#         "Known PySide2 x Python incompatibility: "
-#         "... object cannot be interpreted as an integer",
-#         allow_module_level=True,
-#     )
+if qtpy.API_NAME == 'PySide2' and sys.version_info[:2] > (3, 10):
+    pytest.skip(
+        "Known PySide2 x Python incompatibility: "
+        "... object cannot be interpreted as an integer",
+        allow_module_level=True,
+    )
+
 from napari_plugin_manager import qt_plugin_dialog
 from napari_plugin_manager.qt_package_installer import InstallerActions
 

--- a/napari_plugin_manager/_tests/test_qt_plugin_dialog.py
+++ b/napari_plugin_manager/_tests/test_qt_plugin_dialog.py
@@ -14,15 +14,14 @@ from napari.utils.translations import trans
 from qtpy.QtCore import QMimeData, QPointF, Qt, QUrl
 from qtpy.QtGui import QDropEvent
 
-if (qtpy.API_NAME == 'PySide2') or (
-    sys.version_info[:2] > (3, 10) and platform.system() == "Linux"
-):
-    pytest.skip(
-        "Known PySide2 x Python incompatibility: "
-        "... object cannot be interpreted as an integer",
-        allow_module_level=True,
-    )
-
+# if (qtpy.API_NAME == 'PySide2') or (
+#     sys.version_info[:2] > (3, 10) and platform.system() == "Linux"
+# ):
+#     pytest.skip(
+#         "Known PySide2 x Python incompatibility: "
+#         "... object cannot be interpreted as an integer",
+#         allow_module_level=True,
+#     )
 from napari_plugin_manager import qt_plugin_dialog
 from napari_plugin_manager.qt_package_installer import InstallerActions
 

--- a/napari_plugin_manager/qt_plugin_dialog.py
+++ b/napari_plugin_manager/qt_plugin_dialog.py
@@ -17,6 +17,7 @@ from napari._qt.widgets.qt_tooltip import QtToolTipLabel
 from napari.plugins.utils import normalized_name
 from napari.settings import get_settings
 from napari.utils.misc import (
+    StringEnum,
     parse_version,
     running_as_constructor_app,
 )
@@ -104,7 +105,7 @@ class PluginListItem(QFrame):
     author, source, version, and buttons to update, install/uninstall, etc."""
 
     # item, package_name, action_name, version, installer_choice
-    actionRequested = Signal(QListWidgetItem, str, str, str, str)
+    actionRequested = Signal(QListWidgetItem, str, StringEnum, str, StringEnum)
 
     def __init__(
         self,

--- a/napari_plugin_manager/qt_plugin_dialog.py
+++ b/napari_plugin_manager/qt_plugin_dialog.py
@@ -104,9 +104,7 @@ class PluginListItem(QFrame):
     author, source, version, and buttons to update, install/uninstall, etc."""
 
     # item, package_name, action_name, version, installer_choice
-    actionRequested = Signal(
-        QListWidgetItem, str, InstallerActions, str, InstallerTools
-    )
+    actionRequested = Signal(QListWidgetItem, str, str, str, str)
 
     def __init__(
         self,


### PR DESCRIPTION
Closes #94
Closes #103 