### PR TITLE
Prevent being able to install plugins that are only available via PyPI on a bundle installation

### DIFF
--- a/napari_plugin_manager/qt_plugin_dialog.py
+++ b/napari_plugin_manager/qt_plugin_dialog.py
@@ -384,7 +384,7 @@ class PluginListItem(QFrame):
         if IS_NAPARI_CONDA_INSTALLED and self._versions_conda:
             self.source_choice_dropdown.addItem(CONDA)
 
-        if self._versions_pypi:
+        if self._versions_pypi and not ON_BUNDLE:
             self.source_choice_dropdown.addItem(PYPI)
 
         source = self.get_installer_source()
@@ -1190,7 +1190,7 @@ class QtPluginDialog(QDialog):
         self.working_indicator.setMovie(mov)
         mov.start()
 
-        visibility_direct_entry = not running_as_constructor_app()
+        visibility_direct_entry = not ON_BUNDLE
         self.direct_entry_edit = QLineEdit(self)
         self.direct_entry_edit.installEventFilter(self)
         self.direct_entry_edit.returnPressed.connect(self._install_packages)
@@ -1382,7 +1382,7 @@ class QtPluginDialog(QDialog):
                             extra_info['conda_versions'],
                         )
                     )
-                if ON_BUNDLE and not is_available_in_conda:
+                if ON_BUNDLE and len(extra_info['conda_versions']) == 0:
                     self.available_list.tag_unavailable(metadata)
 
             if len(self._plugin_queue) == 0:


### PR DESCRIPTION
Part of #110

Explores the option to prevent installing plugins that are only available through PyPI on bundle installations. This particular implementation uses some previously implemented to tag plugins as unavailable (disabling the install/action button, changing the plugin item style and showing a warning icon + tooltip). A preview:

![imagen](https://github.com/user-attachments/assets/ad554125-205d-4417-bfb3-009effbd4d85)

Note: To check locally the items being disabled and the dialog layout as seen from a bundle installation, you need to replace/change https://github.com/napari/napari-plugin-manager/blob/dbcd36221f27401be5db50a16fe80b6929820222/napari_plugin_manager/qt_plugin_dialog.py#L72-L73

for something like:

```python
ON_BUNDLE = True
IS_NAPARI_CONDA_INSTALLED = True
```

Also, if this option gets favored over PR #111 probably some further styling needs to be done to the 'disabled' plugin items (to properly aling the warning icon, disable the installation info widget, etc)