### PR TITLE
Drop Python 3.9

### DIFF
--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -31,7 +31,7 @@ jobs:
       fail-fast: false
       matrix:
         platform: [ubuntu-latest, windows-latest, macos-13]
-        python-version: ["3.9", "3.10", "3.11"]
+        python-version: ["3.10", "3.11"]
         napari: ["latest", "repo"]
         tool: ["pip", "conda"]
         exclude:
@@ -89,8 +89,6 @@ jobs:
           PYVISTA_OFF_SCREEN: True  # required for opengl on windows
           NAPARI: ${{ matrix.napari }}
           FORCE_COLOR: 1
-          # PySide6 only functional with Python 3.10+
-          TOX_SKIP_ENV: ".*py39-PySide6.*"
 
       - name: Test with tox - conda
         if: matrix.tool == 'conda'
@@ -102,8 +100,6 @@ jobs:
           PYVISTA_OFF_SCREEN: True  # required for opengl on windows
           NAPARI: ${{ matrix.napari }}
           FORCE_COLOR: 1
-          # PySide6 only functional with Python 3.10+
-          TOX_SKIP_ENV: ".*py39-PySide6.*"
 
       - name: Coverage
         uses: codecov/codecov-action@v5

--- a/napari_plugin_manager/_tests/test_installer_process.py
+++ b/napari_plugin_manager/_tests/test_installer_process.py
@@ -346,7 +346,7 @@ def test_constraints_are_in_sync():
 
     name_re = re.compile(r"([a-z0-9_\-]+).*")
     for conda_constraint, pip_constraint in zip(
-        conda_constraints, pip_constraints
+        conda_constraints, pip_constraints, strict=False
     ):
         conda_name = name_re.match(conda_constraint).group(1)
         pip_name = name_re.match(pip_constraint).group(1)

--- a/napari_plugin_manager/_tests/test_qt_plugin_dialog.py
+++ b/napari_plugin_manager/_tests/test_qt_plugin_dialog.py
@@ -2,7 +2,6 @@ import importlib.metadata
 import os
 import sys
 from collections.abc import Generator
-from typing import Tuple
 from unittest.mock import patch
 
 import napari.plugins
@@ -34,7 +33,7 @@ N_MOCKED_PLUGINS = 2
 def _iter_napari_pypi_plugin_info(
     conda_forge: bool = True,
 ) -> Generator[
-    Tuple[npe2.PackageMetadata | None, bool], None, None
+    tuple[npe2.PackageMetadata | None, bool], None, None
 ]:  # pragma: no cover  (this function is used in thread and codecov has a problem with the collection of coverage in such cases)
     """Mock the pypi method to collect available plugins.
 

--- a/napari_plugin_manager/_tests/test_qt_plugin_dialog.py
+++ b/napari_plugin_manager/_tests/test_qt_plugin_dialog.py
@@ -1,7 +1,8 @@
 import importlib.metadata
 import os
 import sys
-from typing import Generator, Optional, Tuple
+from collections.abc import Generator
+from typing import Tuple
 from unittest.mock import patch
 
 import napari.plugins
@@ -33,7 +34,7 @@ N_MOCKED_PLUGINS = 2
 def _iter_napari_pypi_plugin_info(
     conda_forge: bool = True,
 ) -> Generator[
-    Tuple[Optional[npe2.PackageMetadata], bool], None, None
+    Tuple[npe2.PackageMetadata | None, bool], None, None
 ]:  # pragma: no cover  (this function is used in thread and codecov has a problem with the collection of coverage in such cases)
     """Mock the pypi method to collect available plugins.
 

--- a/napari_plugin_manager/base_qt_package_installer.py
+++ b/napari_plugin_manager/base_qt_package_installer.py
@@ -21,7 +21,7 @@ from logging import getLogger
 from pathlib import Path
 from subprocess import call
 from tempfile import gettempdir
-from typing import Deque, Tuple, TypedDict
+from typing import TypedDict
 
 from napari.plugins import plugin_manager
 from napari.plugins.npe2api import _user_agent
@@ -49,7 +49,7 @@ class ProcessFinishedData(TypedDict):
     exit_code: int
     exit_status: int
     action: InstallerActions
-    pkgs: Tuple[str, ...]
+    pkgs: tuple[str, ...]
 
 
 class InstallerTools(StringEnum):
@@ -62,8 +62,8 @@ class InstallerTools(StringEnum):
 @dataclass(frozen=True)
 class AbstractInstallerTool:
     action: InstallerActions
-    pkgs: Tuple[str, ...]
-    origins: Tuple[str, ...] = ()
+    pkgs: tuple[str, ...]
+    origins: tuple[str, ...] = ()
     prefix: str | None = None
     process: QProcess = None
 
@@ -111,7 +111,7 @@ class PipInstallerTool(AbstractInstallerTool):
     def available(cls):
         return call([cls.executable(), "-m", "pip", "--version"]) == 0
 
-    def arguments(self) -> Tuple[str, ...]:
+    def arguments(self) -> tuple[str, ...]:
         args = ['-m', 'pip']
         if self.action == InstallerActions.INSTALL:
             args += ['install', '-c', self._constraints_file()]
@@ -172,7 +172,7 @@ class CondaInstallerTool(AbstractInstallerTool):
         except FileNotFoundError:  # pragma: no cover
             return False
 
-    def arguments(self) -> Tuple[str, ...]:
+    def arguments(self) -> tuple[str, ...]:
         prefix = self.prefix or self._default_prefix()
         if self.action == InstallerActions.UPGRADE:
             args = ['update', '-y', '--prefix', prefix]
@@ -250,7 +250,7 @@ class InstallerQueue(QObject):
         self, parent: QObject | None = None, prefix: str | None = None
     ) -> None:
         super().__init__(parent)
-        self._queue: Deque[AbstractInstallerTool] = deque()
+        self._queue: deque[AbstractInstallerTool] = deque()
         self._current_process: QProcess = None
         self._prefix = prefix
         self._output_widget = None

--- a/napari_plugin_manager/base_qt_package_installer.py
+++ b/napari_plugin_manager/base_qt_package_installer.py
@@ -13,6 +13,7 @@ import contextlib
 import os
 import sys
 from collections import deque
+from collections.abc import Sequence
 from dataclasses import dataclass
 from enum import auto
 from functools import lru_cache
@@ -20,7 +21,7 @@ from logging import getLogger
 from pathlib import Path
 from subprocess import call
 from tempfile import gettempdir
-from typing import Deque, Optional, Sequence, Tuple, TypedDict
+from typing import Deque, Tuple, TypedDict
 
 from napari.plugins import plugin_manager
 from napari.plugins.npe2api import _user_agent
@@ -61,7 +62,7 @@ class AbstractInstallerTool:
     action: InstallerActions
     pkgs: Tuple[str, ...]
     origins: Tuple[str, ...] = ()
-    prefix: Optional[str] = None
+    prefix: str | None = None
     process: QProcess = None
 
     @property
@@ -244,7 +245,7 @@ class InstallerQueue(QObject):
     BASE_PACKAGE_NAME = ''
 
     def __init__(
-        self, parent: Optional[QObject] = None, prefix: Optional[str] = None
+        self, parent: QObject | None = None, prefix: str | None = None
     ) -> None:
         super().__init__(parent)
         self._queue: Deque[AbstractInstallerTool] = deque()
@@ -259,7 +260,7 @@ class InstallerQueue(QObject):
         tool: InstallerTools,
         pkgs: Sequence[str],
         *,
-        prefix: Optional[str] = None,
+        prefix: str | None = None,
         origins: Sequence[str] = (),
         **kwargs,
     ) -> JobId:
@@ -298,7 +299,7 @@ class InstallerQueue(QObject):
         tool: InstallerTools,
         pkgs: Sequence[str],
         *,
-        prefix: Optional[str] = None,
+        prefix: str | None = None,
         origins: Sequence[str] = (),
         **kwargs,
     ) -> JobId:
@@ -337,7 +338,7 @@ class InstallerQueue(QObject):
         tool: InstallerTools,
         pkgs: Sequence[str],
         *,
-        prefix: Optional[str] = None,
+        prefix: str | None = None,
         **kwargs,
     ) -> JobId:
         """Uninstall packages in `pkgs` from `prefix` using `tool`.
@@ -492,7 +493,7 @@ class InstallerQueue(QObject):
         tool: InstallerTools,
         action: InstallerActions,
         pkgs: Sequence[str],
-        prefix: Optional[str] = None,
+        prefix: str | None = None,
         origins: Sequence[str] = (),
         **kwargs,
     ) -> AbstractInstallerTool:
@@ -581,9 +582,9 @@ class InstallerQueue(QObject):
 
     def _on_process_done(
         self,
-        exit_code: Optional[int] = None,
-        exit_status: Optional[QProcess.ExitStatus] = None,
-        error: Optional[QProcess.ProcessError] = None,
+        exit_code: int | None = None,
+        exit_status: QProcess.ExitStatus | None = None,
+        error: QProcess.ProcessError | None = None,
     ):
         item = None
         with contextlib.suppress(IndexError):

--- a/napari_plugin_manager/base_qt_plugin_dialog.py
+++ b/napari_plugin_manager/base_qt_plugin_dialog.py
@@ -308,7 +308,9 @@ class BasePluginListItem(QFrame):
     def set_busy(
         self,
         text: str,
-        action_name: Literal['install', 'uninstall', 'cancel', 'upgrade'] | None = None,
+        action_name: (
+            Literal['install', 'uninstall', 'cancel', 'upgrade'] | None
+        ) = None,
     ):
         """Updates status text and what buttons are visible when any button is pushed.
 

--- a/napari_plugin_manager/base_qt_plugin_dialog.py
+++ b/napari_plugin_manager/base_qt_plugin_dialog.py
@@ -2,6 +2,7 @@ import contextlib
 import importlib.metadata
 import os
 import webbrowser
+from collections.abc import Sequence
 from functools import partial
 from typing import (
     Any,
@@ -9,9 +10,7 @@ from typing import (
     List,
     Literal,
     NamedTuple,
-    Optional,
     Protocol,
-    Sequence,
     Tuple,
 )
 
@@ -147,13 +146,13 @@ class BasePluginListItem(QFrame):
         author: str = '',
         license: str = "UNKNOWN",  # noqa: A002
         *,
-        plugin_name: Optional[str] = None,
+        plugin_name: str | None = None,
         parent: QWidget = None,
         enabled: bool = True,
         installed: bool = False,
         plugin_api_version=1,
-        versions_conda: Optional[List[str]] = None,
-        versions_pypi: Optional[List[str]] = None,
+        versions_conda: List[str] | None = None,
+        versions_pypi: List[str] | None = None,
         prefix=None,
     ) -> None:
         super().__init__(parent)
@@ -309,9 +308,7 @@ class BasePluginListItem(QFrame):
     def set_busy(
         self,
         text: str,
-        action_name: Optional[
-            Literal['install', 'uninstall', 'cancel', 'upgrade']
-        ] = None,
+        action_name: Literal['install', 'uninstall', 'cancel', 'upgrade'] | None = None,
     ):
         """Updates status text and what buttons are visible when any button is pushed.
 
@@ -832,8 +829,8 @@ class BaseQPluginList(QListWidget):
         item: QListWidgetItem,
         pkg_name: str,
         action_name: InstallerActions,
-        version: Optional[str] = None,
-        installer_choice: Optional[str] = None,
+        version: str | None = None,
+        installer_choice: str | None = None,
     ):
         """Determine which action is called (install, uninstall, update, cancel).
         Update buttons appropriately and run the action."""
@@ -1259,7 +1256,7 @@ class BaseQtPluginDialog(QDialog):
         self._add_items_timer.start()
         self._update_plugin_count()
 
-    def _add_installed(self, pkg_name: Optional[str] = None) -> None:
+    def _add_installed(self, pkg_name: str | None = None) -> None:
         """
         Add plugins that are installed to the dialog.
 
@@ -1758,7 +1755,7 @@ class BaseQtPluginDialog(QDialog):
 
     # region - Public methods
     # ------------------------------------------------------------------------
-    def search(self, text: Optional[str] = None, skip=False) -> None:
+    def search(self, text: str | None = None, skip=False) -> None:
         """Filter by text or set current text as filter."""
         if text is None:
             text = self.packages_search.text()

--- a/napari_plugin_manager/base_qt_plugin_dialog.py
+++ b/napari_plugin_manager/base_qt_plugin_dialog.py
@@ -6,12 +6,9 @@ from collections.abc import Sequence
 from functools import partial
 from typing import (
     Any,
-    Dict,
-    List,
     Literal,
     NamedTuple,
     Protocol,
-    Tuple,
 )
 
 from packaging.version import parse as parse_version
@@ -113,8 +110,8 @@ class BasePackageMetadata(NamedTuple):
 class BaseProjectInfoVersions(NamedTuple):
     metadata: BasePackageMetadata
     display_name: str
-    pypi_versions: List[str]
-    conda_versions: List[str]
+    pypi_versions: list[str]
+    conda_versions: list[str]
 
 
 class BasePluginListItem(QFrame):
@@ -151,8 +148,8 @@ class BasePluginListItem(QFrame):
         enabled: bool = True,
         installed: bool = False,
         plugin_api_version=1,
-        versions_conda: List[str] | None = None,
-        versions_pypi: List[str] | None = None,
+        versions_conda: list[str] | None = None,
+        versions_pypi: list[str] | None = None,
         prefix=None,
     ) -> None:
         super().__init__(parent)
@@ -1669,7 +1666,7 @@ class BaseQtPluginDialog(QDialog):
 
         self._update_plugin_count()
 
-    def _handle_yield(self, data: Tuple[PackageMetadataProtocol, bool, Dict]):
+    def _handle_yield(self, data: tuple[PackageMetadataProtocol, bool, dict]):
         """Output from a worker process.
 
         Includes information about the plugin, including available versions on conda and pypi.

--- a/napari_plugin_manager/npe2api.py
+++ b/napari_plugin_manager/npe2api.py
@@ -8,7 +8,6 @@ from collections.abc import Iterator
 from concurrent.futures import ThreadPoolExecutor
 from functools import lru_cache
 from typing import (
-    Optional,
     TypedDict,
     cast,
 )
@@ -75,7 +74,7 @@ def plugin_summaries() -> list[SummaryDict]:
 
 
 @lru_cache
-def conda_map() -> dict[PyPIname, Optional[str]]:
+def conda_map() -> dict[PyPIname, str | None]:
     """Return map of PyPI package name to conda_channel/package_name ()."""
     url = 'https://npe2api.vercel.app/api/conda'
     with urlopen(Request(url, headers={'User-Agent': _user_agent()})) as resp:

--- a/napari_plugin_manager/qt_package_installer.py
+++ b/napari_plugin_manager/qt_package_installer.py
@@ -10,10 +10,10 @@ by a `deque` of `*InstallerTool` dataclasses (`NapariPipInstallerTool` and
 import atexit
 import os
 import sys
+from collections.abc import Sequence
 from functools import lru_cache
 from pathlib import Path
 from tempfile import NamedTemporaryFile
-from typing import Sequence
 
 from napari._version import version as _napari_version
 from napari._version import version_tuple as _napari_version_tuple

--- a/napari_plugin_manager/utils.py
+++ b/napari_plugin_manager/utils.py
@@ -1,10 +1,9 @@
 import re
 import sys
 from pathlib import Path
-from typing import Optional
 
 
-def is_conda_package(pkg: str, prefix: Optional[str] = None) -> bool:
+def is_conda_package(pkg: str, prefix: str | None = None) -> bool:
     """Determines if plugin was installed through conda.
 
     Returns

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -154,7 +154,7 @@ exclude = [
     "*_vendor*",
 ]
 
-target-version = "py38"
+target-version = "py310"
 fix = true
 
 [tool.ruff.per-file-ignores]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -98,6 +98,10 @@ ignore = [
 
 [tool.ruff]
 line-length = 79
+target-version = "py310"
+fix = true
+
+[tool.ruff.lint]
 select = [
     "E", "F", "W", #flake8
     "UP", # pyupgrade
@@ -153,9 +157,6 @@ exclude = [
     "*vendored*",
     "*_vendor*",
 ]
-
-target-version = "py310"
-fix = true
 
 [tool.ruff.per-file-ignores]
 "**/_tests/*.py" = ["B011", "INP001", "TRY301"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,6 @@ classifiers = [
     "Programming Language :: C",
     "Programming Language :: Python",
     "Programming Language :: Python :: 3 :: Only",
-    "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Topic :: Scientific/Engineering",
@@ -46,7 +45,7 @@ classifiers = [
     "Operating System :: Unix",
     "Operating System :: MacOS"
 ]
-requires-python = ">=3.8"
+requires-python = ">=3.10"
 dependencies = [
   "npe2",
   "qtpy",
@@ -86,7 +85,7 @@ docs = [
 homepage = "https://github.com/napari/napari-plugin-manager"
 
 [tool.black]
-target-version = ['py39', 'py310', 'py311']
+target-version = ['py310', 'py311']
 skip-string-normalization = true
 line-length = 79
 
@@ -126,7 +125,6 @@ ignore = [
     "E501", "UP006", "TCH001", "TCH002", "TCH003",
     "A003", # flake8-builtins - we have class attributes violating these rule
     "COM812", # flake8-commas - we don't like adding comma on single line of arguments
-    "SIM117", # flake8-simplify - we some of merged with statements are not looking great with black, reanble after drop python 3.9
     "Q000",
     "RET504", # not fixed yet https://github.com/charliermarsh/ruff/issues/2950
     "TRY003", # require implement multiple exception class

--- a/tox.ini
+++ b/tox.ini
@@ -1,13 +1,11 @@
 # For more information about tox, see https://tox.readthedocs.io/en/latest/
 [tox]
-envlist = py{39,310,311}-{PyQt5,PySide2,PyQt6,PySide6}-napari_{latest,repo}
+envlist = py{310,311}-{PyQt5,PySide2,PyQt6,PySide6}-napari_{latest,repo}
 toxworkdir=/tmp/.tox
 isolated_build = true
 
 [gh-actions]
 python =
-    3.8: py38
-    3.9: py39
     3.10: py310
     3.11: py311
 


### PR DESCRIPTION
Since napari has already dropped Python 3.9, this PR updates the plugin manager to also drop it.