### PR TITLE
Try to ensure conda workflow case installs from conda

### DIFF
--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -93,6 +93,7 @@ jobs:
         env:
           PYVISTA_OFF_SCREEN: True  # required for opengl on windows
           NAPARI: ${{ matrix.napari }}
+          TOOL: ${{ matrix.tool }}
           FORCE_COLOR: 1
           
       - name: Test with tox - conda
@@ -104,6 +105,7 @@ jobs:
         env:
           PYVISTA_OFF_SCREEN: True  # required for opengl on windows
           NAPARI: ${{ matrix.napari }}
+          TOOL: ${{ matrix.tool }}
           FORCE_COLOR: 1
           
       - name: Upload coverage data

--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -31,27 +31,23 @@ jobs:
       fail-fast: false
       matrix:
         platform: [ubuntu-latest, windows-latest, macos-13, macos-latest]
-        python-version: ["3.10", "3.12"]
+        python-version: ["3.10", "3.11", "3.12"]
         napari: ["latest", "repo"]
         tool: ["pip", "conda"]
         include:
-        # run more checks on ubuntu as smoke tests
-          - platform: ubuntu-latest
-            python-version: "3.11"
-          - platform: ubuntu-latest
+          # add 3.13 on ubuntu
+          - platform: ubuntu
+            napari: repo
+            tool: pip
             python-version: "3.13"
         exclude:
-        # no Qt backends on conda-forge for py313
-          - python-version: "3.13"
-            tool: "conda"
-          # just do the release install on mac/windows
-          - platform: macos-13
-            napari: repo
-          - platform: macos-latest
-            napari: repo
-          - platform: windows-latest
-            napari: repo
-
+        # skip repo install on mac and windows
+        - platform: windows-latest
+          napari: repo
+        - platform: macos-13
+          napari: repo
+        - platform: macos-latest
+          napari: repo
 
     steps:
       - uses: actions/checkout@v4
@@ -105,7 +101,7 @@ jobs:
           TOOL: ${{ matrix.tool }}
           FORCE_COLOR: 1
           # Only supported pyside6 is not supported on py312, py313
-          TOX_SKIP_ENV: "pip-py31[23].*PySide6"
+          TOX_SKIP_ENV: ".*py31[23].*PySide6"
           
       - name: Test with tox - conda
         if: matrix.tool == 'conda'
@@ -118,6 +114,10 @@ jobs:
           NAPARI: ${{ matrix.napari }}
           TOOL: ${{ matrix.tool }}
           FORCE_COLOR: 1
+          # Only supported pyside6 is not supported on py312, py313
+          # no Qt backends supported by conda-forge on py313
+          TOX_SKIP_ENV: ".*py31[23].*PySide6 | .*py313.*conda"
+
           
       - name: Upload coverage data
         uses: actions/upload-artifact@v4

--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -100,7 +100,7 @@ jobs:
           TOOL: ${{ matrix.tool }}
           FORCE_COLOR: 1
           # Only supported pyside6 is not supported on py312, py313
-          TOX_SKIP_ENV: "py31[23].*PySide6"
+          TOX_SKIP_ENV: "pip-py31[23].*PySide6"
           
       - name: Test with tox - conda
         if: matrix.tool == 'conda'

--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -31,22 +31,27 @@ jobs:
       fail-fast: false
       matrix:
         platform: [ubuntu-latest, windows-latest, macos-13, macos-latest]
-        python-version: ["3.10", "3.13"]
+        python-version: ["3.10", "3.12"]
         napari: ["latest", "repo"]
         tool: ["pip", "conda"]
         include:
+        # run more checks on ubuntu as smoke tests
           - platform: ubuntu-latest
             python-version: "3.11"
-            napari: "latest"
-            tool: "pip"
           - platform: ubuntu-latest
-            python-version: "3.12"
-            napari: "latest"
-            tool: "pip"
+            python-version: "3.13"
         exclude:
         # no Qt backends on conda-forge for py313
           - python-version: "3.13"
             tool: "conda"
+          # just do the release install on mac/windows
+          - platform: macos-13
+            napari: repo
+          - platform: macos-latest
+            napari: repo
+          - platform: windows-latest
+            napari: repo
+
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -41,7 +41,10 @@ jobs:
             tool: pip
             python-version: "3.13"
         exclude:
-        # skip repo install on mac and windows
+        # skip repo install on conda
+        - platform: ubuntu-latest
+          napari: repo
+          tool: conda
         - platform: windows-latest
           napari: repo
         - platform: macos-13
@@ -116,7 +119,7 @@ jobs:
           FORCE_COLOR: 1
           # Only supported pyside6 is not supported on py312, py313
           # no Qt backends supported by conda-forge on py313
-          TOX_SKIP_ENV: ".*py31[23].*PySide6 | .*py313.*conda"
+          TOX_SKIP_ENV: ".*py31[23].*PySide6|.*py313.*conda"
 
           
       - name: Upload coverage data

--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -43,6 +43,10 @@ jobs:
             python-version: "3.12"
             napari: "latest"
             tool: "pip"
+        exclude:
+        # no Qt backends on conda-forge for py313
+          - python-version: "3.13"
+            tool: "conda"
 
     steps:
       - uses: actions/checkout@v4
@@ -95,6 +99,8 @@ jobs:
           NAPARI: ${{ matrix.napari }}
           TOOL: ${{ matrix.tool }}
           FORCE_COLOR: 1
+          # Only supported pyside6 is not supported on py312, py313
+          TOX_SKIP_ENV: "py31[23].*PySide6"
           
       - name: Test with tox - conda
         if: matrix.tool == 'conda'

--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -58,6 +58,8 @@ jobs:
         uses: conda-incubator/setup-miniconda@v3
         with:
           miniforge-version: latest
+          channels: conda-forge
+          conda-remove-defaults: "true"
           python-version: ${{ matrix.python-version }}
 
       - uses: tlambert03/setup-qt-libs@v1
@@ -92,9 +94,7 @@ jobs:
           PYVISTA_OFF_SCREEN: True  # required for opengl on windows
           NAPARI: ${{ matrix.napari }}
           FORCE_COLOR: 1
-          TOX_SKIP_ENV: |
-            ${{ (matrix.platform == 'macos-latest' && '.*PySide2.*') || '.*py3(11|12|13)-PySide2.*'  }}
-
+          
       - name: Test with tox - conda
         if: matrix.tool == 'conda'
         uses: aganders3/headless-gui@v2
@@ -105,8 +105,7 @@ jobs:
           PYVISTA_OFF_SCREEN: True  # required for opengl on windows
           NAPARI: ${{ matrix.napari }}
           FORCE_COLOR: 1
-          TOX_SKIP_ENV:  ${{ (matrix.platform == 'macos-latest' && '.*py3(10|13)-PySide2.*') || '.*py313-PySide2.*'  }}
-
+          
       - name: Upload coverage data
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -36,7 +36,7 @@ jobs:
         tool: ["pip", "conda"]
         include:
           # add 3.13 on ubuntu
-          - platform: ubuntu
+          - platform: ubuntu-latest
             napari: repo
             tool: pip
             python-version: "3.13"

--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -117,9 +117,9 @@ jobs:
           NAPARI: ${{ matrix.napari }}
           TOOL: ${{ matrix.tool }}
           FORCE_COLOR: 1
-          # Only supported pyside6 is not supported on py312, py313
+          # Only supported pyside2 and pyside6 are not supported on py312, py313
           # no Qt backends supported by conda-forge on py313
-          TOX_SKIP_ENV: ".*py31[23].*PySide6|.*py313.*conda"
+          TOX_SKIP_ENV: ".*py31[23].*PySide[26]|.*py313.*conda"
 
           
       - name: Upload coverage data

--- a/src/napari_plugin_manager/_tests/test_qt_plugin_dialog.py
+++ b/src/napari_plugin_manager/_tests/test_qt_plugin_dialog.py
@@ -25,7 +25,10 @@ if qtpy.API_NAME == 'PySide2' and sys.version_info[:2] > (3, 10):
     )
 
 from napari_plugin_manager import qt_plugin_dialog
-from napari_plugin_manager.base_qt_package_installer import InstallerActions, InstallerTools
+from napari_plugin_manager.base_qt_package_installer import (
+    InstallerActions,
+    InstallerTools,
+)
 
 N_MOCKED_PLUGINS = 2
 
@@ -503,8 +506,16 @@ def test_install_pypi_constructor(
             reason="This test is only relevant for constructor-based installs"
         )
     # ensure pip is the installer tool, so that the warning will trigger
-    monkeypatch.setattr(qt_plugin_dialog.PluginListItem, 'get_installer_tool', lambda self: InstallerTools.PIP)
-    monkeypatch.setattr(qt_plugin_dialog.PluginListItem, 'get_installer_source', lambda self: "PIP")
+    monkeypatch.setattr(
+        qt_plugin_dialog.PluginListItem,
+        'get_installer_tool',
+        lambda self: InstallerTools.PIP,
+    )
+    monkeypatch.setattr(
+        qt_plugin_dialog.PluginListItem,
+        'get_installer_source',
+        lambda self: "PIP",
+    )
 
     plugin_dialog.set_prefix(str(tmp_virtualenv))
     plugin_dialog.search('requests')

--- a/src/napari_plugin_manager/_tests/test_qt_plugin_dialog.py
+++ b/src/napari_plugin_manager/_tests/test_qt_plugin_dialog.py
@@ -25,7 +25,7 @@ if qtpy.API_NAME == 'PySide2' and sys.version_info[:2] > (3, 10):
     )
 
 from napari_plugin_manager import qt_plugin_dialog
-from napari_plugin_manager.base_qt_package_installer import InstallerActions
+from napari_plugin_manager.base_qt_package_installer import InstallerActions, InstallerTools
 
 N_MOCKED_PLUGINS = 2
 
@@ -496,12 +496,15 @@ def test_installs(qtbot, tmp_virtualenv, plugin_dialog, request):
     [QMessageBox.StandardButton.Cancel, QMessageBox.StandardButton.Ok],
 )
 def test_install_pypi_constructor(
-    qtbot, tmp_virtualenv, plugin_dialog, request, message_return
+    qtbot, tmp_virtualenv, plugin_dialog, request, message_return, monkeypatch
 ):
-    if "no-constructor" in request.node.name:
+    if "constructor" not in request.node.name:
         pytest.skip(
             reason="This test is only relevant for constructor-based installs"
         )
+    # ensure pip is the installer tool, so that the warning will trigger
+    monkeypatch.setattr(qt_plugin_dialog.PluginListItem, 'get_installer_tool', lambda self: InstallerTools.PIP)
+    monkeypatch.setattr(qt_plugin_dialog.PluginListItem, 'get_installer_source', lambda self: "PIP")
 
     plugin_dialog.set_prefix(str(tmp_virtualenv))
     plugin_dialog.search('requests')

--- a/src/napari_plugin_manager/_tests/test_qt_plugin_dialog.py
+++ b/src/napari_plugin_manager/_tests/test_qt_plugin_dialog.py
@@ -278,7 +278,7 @@ def test_visible_widgets(request, plugin_dialog):
     """
     Test that the direct entry button and textbox are visible
     """
-    if "no-constructor" not in request.node.name:
+    if "constructor" in request.node.name:
         pytest.skip(
             reason="Tested functionality not available in constructor-based installs"
         )
@@ -472,7 +472,7 @@ def test_drop_event(plugin_dialog, tmp_path):
 def test_installs(qtbot, tmp_virtualenv, plugin_dialog, request):
     if "[constructor]" in request.node.name:
         pytest.skip(
-            reason="This test is only relevant for constructor-based installs"
+            reason="This test is only relevant for non-constructor-based installs"
         )
 
     plugin_dialog.set_prefix(str(tmp_virtualenv))
@@ -524,7 +524,7 @@ def test_install_pypi_constructor(
 def test_cancel(qtbot, tmp_virtualenv, plugin_dialog, request):
     if "[constructor]" in request.node.name:
         pytest.skip(
-            reason="This test is only relevant for constructor-based installs"
+            reason="This test is only relevant for non-constructor-based installs"
         )
 
     plugin_dialog.set_prefix(str(tmp_virtualenv))
@@ -548,7 +548,7 @@ def test_cancel(qtbot, tmp_virtualenv, plugin_dialog, request):
 def test_cancel_all(qtbot, tmp_virtualenv, plugin_dialog, request):
     if "[constructor]" in request.node.name:
         pytest.skip(
-            reason="This test is only relevant for constructor-based installs"
+            reason="This test is only relevant for non-constructor-based installs"
         )
 
     plugin_dialog.set_prefix(str(tmp_virtualenv))
@@ -575,7 +575,7 @@ def test_cancel_all(qtbot, tmp_virtualenv, plugin_dialog, request):
 def test_direct_entry_installs(qtbot, tmp_virtualenv, plugin_dialog, request):
     if "[constructor]" in request.node.name:
         pytest.skip(
-            reason="This test is only relevant for constructor-based installs"
+            reason="The tested functionality is not available in constructor-based installs"
         )
 
     plugin_dialog.set_prefix(str(tmp_virtualenv))

--- a/src/napari_plugin_manager/_tests/test_qt_plugin_dialog.py
+++ b/src/napari_plugin_manager/_tests/test_qt_plugin_dialog.py
@@ -501,9 +501,9 @@ def test_installs(qtbot, tmp_virtualenv, plugin_dialog, request):
 def test_install_pypi_constructor(
     qtbot, tmp_virtualenv, plugin_dialog, request, message_return, monkeypatch
 ):
-    if "constructor" not in request.node.name:
+    if "no-constructor" in request.node.name:
         pytest.skip(
-            reason="This test is only relevant for constructor-based installs"
+            reason="This test is to test pip in constructor-based installs"
         )
     # ensure pip is the installer tool, so that the warning will trigger
     monkeypatch.setattr(

--- a/tox.ini
+++ b/tox.ini
@@ -34,25 +34,24 @@ passenv =
     NUMPY_EXPERIMENTAL_ARRAY_FUNCTION
     PYVISTA_OFF_SCREEN
 
-[testenv]
 deps = 
     napari_repo: git+https://github.com/napari/napari.git
 
 # Conditional PIP dependencies based on environment variables
 [testenv:pip-{py310,py311,py312,py313}-{PyQt5,PyQt6,PySide6}-napari_{latest,repo}]
 deps =
-    {py310,py311,py312,py313}-PyQt5: PyQt5 PyQt5-sip
-    {py310,py311,py312,py313}-PyQt5: PyQt5-sip
-    {py310,py311,py312,py313}-PyQt6: PyQt6
-    {py310,py311,py312,py313}-PySide6: PySide6 != 6.4.3, !=6.5.0, !=6.5.1, !=6.5.1.1, !=6.5.2, != 6.5.3, != 6.6.0, != 6.6.1, != 6.6.2 ; python_version >= '3.10' and python_version < '3.14'
+    PyQt5: PyQt5 PyQt5-sip
+    PyQt5: PyQt5-sip
+    PyQt6: PyQt6
+    PySide6: PySide6 != 6.4.3, !=6.5.0, !=6.5.1, !=6.5.1.1, !=6.5.2, != 6.5.3, != 6.6.0, != 6.6.1, != 6.6.2 ; python_version >= '3.10' and python_version < '3.14'
     napari_latest: napari
 
 # Conditional dependencies for CONDA
 [testenv:conda-{py310,py311,py312,py313}-{PyQt5,PySide2,PySide6}-napari_{latest,repo}]
 conda_deps =
-    {py310,py311,py312,py313}-PyQt5: pyqt
+    PyQt5: pyqt
     {py310,py311}-PySide2: pyside2
-    {py310,py311,py312,py313}-PySide6: pyside6 != 6.4.3, !=6.5.0, !=6.5.1, !=6.5.1.1, !=6.5.2, != 6.5.3, != 6.6.0, != 6.6.1, != 6.6.2 ; python_version >= '3.10' and python_version < '3.14'
+    PySide6: pyside6 != 6.4.3, !=6.5.0, !=6.5.1, !=6.5.1.1, !=6.5.2, != 6.5.3, != 6.6.0, != 6.6.1, != 6.6.2 ; python_version >= '3.10' and python_version < '3.14'
     napari_latest: napari
 
 extras = testing

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 # For more information about tox, see https://tox.readthedocs.io/en/latest/
 [tox]
-envlist = {pip,conda}-py{310,311,312,313}-{PyQt5,PySide2,PyQt6,PySide6}-napari_{latest,repo}
+envlist = pip-py{310,311,312,313}-{PyQt5,PyQt6,PySide6}-napari_{latest,repo}, conda-{py310,py311,py312}-{PyQt5,PySide2,PySide6}-napari_{latest,repo}
 toxworkdir=/tmp/.tox
 isolated_build = true
 
@@ -52,5 +52,3 @@ conda_deps =
     {py310,py311}-PySide2: pyside2
     {py310,py311}-PySide6: pyside6 = 6.4.2
     napari_latest: napari
-
-

--- a/tox.ini
+++ b/tox.ini
@@ -12,16 +12,6 @@ python =
     3.13: py313
 
 [gh-actions:env]
-NAPARI =
-    latest: napari_latest
-    repo: napari_repo
-BACKEND =
-    pyqt: PyQt5
-    pyside: PySide2
-    PyQt5: PyQt5
-    PySide2: PySide2
-    PyQt6: PyQt6
-    PySide6: PySide6
 TOOL =
     pip: pip
     conda: conda
@@ -45,7 +35,7 @@ commands = coverage run --parallel-mode -m pytest -v --color=yes
 # Conditional PIP dependencies based on environment variables
 [testenv:pip-{py310,py311,py312,py313}-{PyQt5,PyQt6,PySide6}-napari_{latest,repo}]
 deps =
-    PyQt5: PyQt5 PyQt5-sip
+    PyQt5: PyQt5
     PyQt5: PyQt5-sip
     PyQt6: PyQt6
     PySide6: PySide6 != 6.4.3, !=6.5.0, !=6.5.1, !=6.5.1.1, !=6.5.2, != 6.5.3, != 6.6.0, != 6.6.1, != 6.6.2 ; python_version >= '3.10' and python_version < '3.14'

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 # For more information about tox, see https://tox.readthedocs.io/en/latest/
 [tox]
-envlist = py{310,311,312,313}-{PyQt5,PySide2,PyQt6,PySide6}-napari_{latest,repo}
+envlist = {pip,conda}-py{310,311,312,313}-{PyQt5,PySide2,PyQt6,PySide6}-napari_{latest,repo}
 toxworkdir=/tmp/.tox
 isolated_build = true
 
@@ -36,6 +36,8 @@ passenv =
 
 deps = 
     napari_repo: git+https://github.com/napari/napari.git
+extras = testing
+commands = coverage run --parallel-mode -m pytest -v --color=yes
 
 # Conditional PIP dependencies based on environment variables
 [testenv:pip-{py310,py311,py312,py313}-{PyQt5,PyQt6,PySide6}-napari_{latest,repo}]
@@ -54,5 +56,4 @@ conda_deps =
     PySide6: pyside6 != 6.4.3, !=6.5.0, !=6.5.1, !=6.5.1.1, !=6.5.2, != 6.5.3, != 6.6.0, != 6.6.1, != 6.6.2 ; python_version >= '3.10' and python_version < '3.14'
     napari_latest: napari
 
-extras = testing
-commands = coverage run --parallel-mode -m pytest -v --color=yes
+

--- a/tox.ini
+++ b/tox.ini
@@ -22,6 +22,9 @@ BACKEND =
     PySide2: PySide2
     PyQt6: PyQt6
     PySide6: PySide6
+TOOL =
+    pip: pip
+    conda: conda
 
 [testenv]
 passenv =

--- a/tox.ini
+++ b/tox.ini
@@ -3,6 +3,7 @@
 envlist = {pip,conda}-py{310,311,312,313}-{PyQt5,PySide2,PyQt6,PySide6}-napari_{latest,repo}
 toxworkdir=/tmp/.tox
 isolated_build = true
+requires = tox-conda tox-gh-actions tox-uv
 
 [gh-actions]
 python =

--- a/tox.ini
+++ b/tox.ini
@@ -34,15 +34,21 @@ passenv =
     NUMPY_EXPERIMENTAL_ARRAY_FUNCTION
     PYVISTA_OFF_SCREEN
 
+[testenv]
+deps = 
+    napari_repo: git+https://github.com/napari/napari.git
+
 # Conditional PIP dependencies based on environment variables
+[testenv:pip-{py310,py311,py312,py313}-{PyQt5,PyQt6,PySide6}-napari_{latest,repo}]
 deps =
     {py310,py311,py312,py313}-PyQt5: PyQt5 PyQt5-sip
+    {py310,py311,py312,py313}-PyQt5: PyQt5-sip
     {py310,py311,py312,py313}-PyQt6: PyQt6
     {py310,py311,py312,py313}-PySide6: PySide6 != 6.4.3, !=6.5.0, !=6.5.1, !=6.5.1.1, !=6.5.2, != 6.5.3, != 6.6.0, != 6.6.1, != 6.6.2 ; python_version >= '3.10' and python_version < '3.14'
-    napari_repo: git+https://github.com/napari/napari.git
     napari_latest: napari
 
 # Conditional dependencies for CONDA
+[testenv:conda-{py310,py311,py312,py313}-{PyQt5,PySide2,PySide6}-napari_{latest,repo}]
 conda_deps =
     {py310,py311,py312,py313}-PyQt5: pyqt
     {py310,py311}-PySide2: pyside2

--- a/tox.ini
+++ b/tox.ini
@@ -46,7 +46,7 @@ deps =
     napari_repo: git+https://github.com/napari/napari.git
 
 # Conditional dependencies for CONDA
-[testenv:conda-{py310,py311,py312,py313}-{PyQt5,PySide2,PySide6}-napari_{latest,repo}]
+[testenv:conda-{py310,py311,py312}-{PyQt5,PySide2,PySide6}-napari_{latest,repo}]
 conda_deps =
     {py310,py311,py312}-PyQt5: pyqt
     {py310,py311}-PySide2: pyside2

--- a/tox.ini
+++ b/tox.ini
@@ -41,15 +41,16 @@ deps =
     PyQt5: PyQt5
     PyQt5: PyQt5-sip
     PyQt6: PyQt6
-    PySide6: PySide6 != 6.4.3, !=6.5.0, !=6.5.1, !=6.5.1.1, !=6.5.2, != 6.5.3, != 6.6.0, != 6.6.1, != 6.6.2 ; python_version >= '3.10' and python_version < '3.14'
+    {py310,py311}-PySide6: PySide6 == 6.4.2 
     napari_latest: napari
+    napari_repo: git+https://github.com/napari/napari.git
 
 # Conditional dependencies for CONDA
 [testenv:conda-{py310,py311,py312,py313}-{PyQt5,PySide2,PySide6}-napari_{latest,repo}]
 conda_deps =
     PyQt5: pyqt
     {py310,py311}-PySide2: pyside2
-    PySide6: pyside6 != 6.4.3, !=6.5.0, !=6.5.1, !=6.5.1.1, !=6.5.2, != 6.5.3, != 6.6.0, != 6.6.1, != 6.6.2 ; python_version >= '3.10' and python_version < '3.14'
+    {py310,py311}-PySide6: pyside6 = 6.4.2
     napari_latest: napari
 
 

--- a/tox.ini
+++ b/tox.ini
@@ -33,15 +33,21 @@ passenv =
     XAUTHORITY
     NUMPY_EXPERIMENTAL_ARRAY_FUNCTION
     PYVISTA_OFF_SCREEN
-deps = 
-    PyQt5: PyQt5
-    PyQt5: PyQt5-sip
-    PySide2: PySide2
-    PyQt6: PyQt6
-    # fix PySide6 when a new napari release is out
-    PySide6: PySide6 != 6.4.3, !=6.5.0, !=6.5.1, !=6.5.1.1, !=6.5.2, != 6.5.3, != 6.6.0, != 6.6.1, != 6.6.2 ; python_version >= '3.10' and python_version < '3.14'
-    PySide2: npe2!=0.2.2
+
+# Conditional PIP dependencies based on environment variables
+deps =
+    {py310,py311,py312,py313}-PyQt5: PyQt5 PyQt5-sip
+    {py310,py311,py312,py313}-PyQt6: PyQt6
+    {py310,py311,py312,py313}-PySide6: PySide6 != 6.4.3, !=6.5.0, !=6.5.1, !=6.5.1.1, !=6.5.2, != 6.5.3, != 6.6.0, != 6.6.1, != 6.6.2 ; python_version >= '3.10' and python_version < '3.14'
     napari_repo: git+https://github.com/napari/napari.git
     napari_latest: napari
+
+# Conditional dependencies for CONDA
+conda_deps =
+    {py310,py311,py312,py313}-PyQt5: pyqt
+    {py310,py311}-PySide2: pyside2
+    {py310,py311,py312,py313}-PySide6: pyside6 != 6.4.3, !=6.5.0, !=6.5.1, !=6.5.1.1, !=6.5.2, != 6.5.3, != 6.6.0, != 6.6.1, != 6.6.2 ; python_version >= '3.10' and python_version < '3.14'
+    napari_latest: napari
+
 extras = testing
 commands = coverage run --parallel-mode -m pytest -v --color=yes

--- a/tox.ini
+++ b/tox.ini
@@ -48,7 +48,7 @@ deps =
 # Conditional dependencies for CONDA
 [testenv:conda-{py310,py311,py312,py313}-{PyQt5,PySide2,PySide6}-napari_{latest,repo}]
 conda_deps =
-    PyQt5: pyqt
+    {py310,py311,py312}-PyQt5: pyqt
     {py310,py311}-PySide2: pyside2
     {py310,py311}-PySide6: pyside6 = 6.4.2
     napari_latest: napari

--- a/tox.ini
+++ b/tox.ini
@@ -12,6 +12,9 @@ python =
     3.13: py313
 
 [gh-actions:env]
+NAPARI =
+    latest: napari_latest
+    repo: napari_repo
 TOOL =
     pip: pip
     conda: conda

--- a/tox.ini
+++ b/tox.ini
@@ -3,7 +3,6 @@
 envlist = {pip,conda}-py{310,311,312,313}-{PyQt5,PySide2,PyQt6,PySide6}-napari_{latest,repo}
 toxworkdir=/tmp/.tox
 isolated_build = true
-requires = tox-conda tox-gh-actions tox-uv
 
 [gh-actions]
 python =


### PR DESCRIPTION
In this PR I try to ensure that dependencies are installed from conda in the conda workflows.
The goal is to address issue is that pyside2 version on pypi (5.15.2.1) isn't compatible with python 3.10.
So here I try to drop that condition.
However, 5.15.15 which is on conda-forge is compatible with 310 and 311 (but not 312 and 313). 
So I add those conditions.
However, conda-forge doesn't have pyqt6, so i remove that.

I've adjusted the matrix a bit to cover more of the relevant cases, particularly on ubuntu.