### PR TITLE
Move restart warning to after dialog is closed

### DIFF
--- a/src/napari_plugin_manager/_tests/test_qt_plugin_dialog.py
+++ b/src/napari_plugin_manager/_tests/test_qt_plugin_dialog.py
@@ -333,11 +333,12 @@ def test_plugin_uninstall_restart_warning(plugin_dialog, qtbot, monkeypatch):
     )
     item = plugin_dialog.installed_list.item(0)
     with patch.object(qt_plugin_dialog.PluginListItem, "set_busy"):
-        plugin_dialog.installed_list.handle_action(
-            item,
-            'my-plugin',
-            InstallerActions.UNINSTALL,
-        )
+        with patch.object(plugin_dialog.installed_list.installer, 'uninstall'):
+            plugin_dialog.installed_list.handle_action(
+                item,
+                'my-plugin',
+                InstallerActions.UNINSTALL,
+            )
         assert plugin_dialog.needs_restart
         plugin_dialog.hide()
         dialog_mock.assert_called_once()

--- a/src/napari_plugin_manager/_tests/test_qt_plugin_dialog.py
+++ b/src/napari_plugin_manager/_tests/test_qt_plugin_dialog.py
@@ -326,23 +326,26 @@ def test_plugin_list_handle_action(plugin_dialog, qtbot):
     qtbot.waitUntil(lambda: not plugin_dialog.worker.is_running)
 
 
-def test_plugin_uninstall_restart_warning(plugin_dialog, qtbot, monkeypatch):
+def test_plugin_install_restart_warning(plugin_dialog, monkeypatch):
     dialog_mock = MagicMock()
     monkeypatch.setattr(
         base_qt_plugin_dialog, 'RestartWarningDialog', dialog_mock
     )
-    item = plugin_dialog.installed_list.item(0)
-    with patch.object(qt_plugin_dialog.PluginListItem, "set_busy"):
-        with patch.object(plugin_dialog.installed_list.installer, 'uninstall'):
-            plugin_dialog.installed_list.handle_action(
-                item,
-                'my-plugin',
-                InstallerActions.UNINSTALL,
-            )
-        assert plugin_dialog.needs_restart
-        plugin_dialog.hide()
-        dialog_mock.assert_called_once()
-    qtbot.waitUntil(lambda: not plugin_dialog.worker.is_running)
+    plugin_dialog.exec_()
+    plugin_dialog.already_installed.add('brand-new-plugin')
+    plugin_dialog.hide()
+    dialog_mock.assert_called_once()
+
+
+def test_plugin_uninstall_restart_warning(plugin_dialog, monkeypatch):
+    dialog_mock = MagicMock()
+    monkeypatch.setattr(
+        base_qt_plugin_dialog, 'RestartWarningDialog', dialog_mock
+    )
+    plugin_dialog.exec_()
+    plugin_dialog.already_installed.remove('my-plugin')
+    plugin_dialog.hide()
+    dialog_mock.assert_called_once()
 
 
 def test_on_enabled_checkbox(plugin_dialog, qtbot, plugins, old_plugins):

--- a/src/napari_plugin_manager/_tests/test_qt_plugin_dialog.py
+++ b/src/napari_plugin_manager/_tests/test_qt_plugin_dialog.py
@@ -93,29 +93,6 @@ def plugins(qtbot):
     return PluginsMock()
 
 
-class WarnPopupMock:
-    def __init__(self, text):
-        self._is_visible = False
-
-    def show(self):
-        self._is_visible = True
-
-    def exec_(self):
-        self._is_visible = True
-
-    def move(self, pos):
-        return False
-
-    def isVisible(self):
-        return self._is_visible
-
-    def close(self):
-        self._is_visible = False
-
-    def width(self):
-        return 100
-
-
 @pytest.fixture(params=[True, False], ids=["constructor", "no-constructor"])
 def plugin_dialog(
     request,
@@ -188,7 +165,6 @@ def plugin_dialog(
         "iter_napari_plugin_info",
         _iter_napari_pypi_plugin_info,
     )
-    monkeypatch.setattr(qt_plugin_dialog, 'WarnPopup', WarnPopupMock)
 
     # This is patching `napari.utils.misc.running_as_constructor_app` function
     # to mock a normal napari install.
@@ -319,14 +295,6 @@ def test_plugin_list_handle_action(plugin_dialog, qtbot):
         mock.assert_called_with(
             trans._("updating..."), InstallerActions.UPGRADE
         )
-
-    with patch.object(qt_plugin_dialog.WarnPopup, "exec_") as mock:
-        plugin_dialog.installed_list.handle_action(
-            item,
-            'my-test-old-plugin-1',
-            InstallerActions.UNINSTALL,
-        )
-        assert mock.called
 
     plugin_dialog.search("requests")
     qtbot.wait(500)

--- a/src/napari_plugin_manager/base_qt_plugin_dialog.py
+++ b/src/napari_plugin_manager/base_qt_plugin_dialog.py
@@ -844,8 +844,6 @@ class BaseQPluginList(QListWidget):
         if not item.text().startswith(self._SORT_ORDER_PREFIX):
             item.setText(f"{self._SORT_ORDER_PREFIX}{item.text()}")
 
-        self._before_handle_action(widget, action_name)
-
         if action_name == InstallerActions.INSTALL:
             if version:
                 pkg_name += (

--- a/src/napari_plugin_manager/base_qt_plugin_dialog.py
+++ b/src/napari_plugin_manager/base_qt_plugin_dialog.py
@@ -57,9 +57,7 @@ from napari_plugin_manager.base_qt_package_installer import (
 )
 from napari_plugin_manager.qt_warning_dialog import RestartWarningDialog
 from napari_plugin_manager.qt_widgets import ClickableLabel
-from napari_plugin_manager.utils import (
-    is_conda_package,
-)
+from napari_plugin_manager.utils import is_conda_package
 
 CONDA = 'Conda'
 PYPI = 'PyPI'

--- a/src/napari_plugin_manager/base_qt_plugin_dialog.py
+++ b/src/napari_plugin_manager/base_qt_plugin_dialog.py
@@ -55,8 +55,12 @@ from napari_plugin_manager.base_qt_package_installer import (
     InstallerTools,
     ProcessFinishedData,
 )
+from napari_plugin_manager.qt_warning_dialog import RestartWarningDialog
 from napari_plugin_manager.qt_widgets import ClickableLabel
-from napari_plugin_manager.utils import is_conda_package
+from napari_plugin_manager.utils import (
+    get_dialog_from_widget,
+    is_conda_package,
+)
 
 CONDA = 'Conda'
 PYPI = 'PyPI'
@@ -888,6 +892,13 @@ class BaseQPluginList(QListWidget):
                 # origins="TODO",
                 # upgrade=False,
             )
+            if (
+                widget.plugin_api_version == 2
+                or widget.plugin_api_version == 'shim'
+            ):
+                parent_dialog = get_dialog_from_widget(widget)
+                if parent_dialog is not None:
+                    parent_dialog.needs_restart = True
             widget.setProperty("current_job_id", job_id)
             if self._warn_dialog:
                 self._warn_dialog.exec_()
@@ -1045,6 +1056,7 @@ class BaseQtPluginDialog(QDialog):
         self.available_set = set()
         self._prefix = prefix
         self._first_open = True
+        self.needs_restart = False
         self._plugin_queue = []  # Store plugin data to be added
         self._plugin_data = []  # Store all plugin data
         self._filter_texts = []
@@ -1750,6 +1762,9 @@ class BaseQtPluginDialog(QDialog):
             self._first_open = False
 
     def hideEvent(self, event):
+        if self.needs_restart:
+            RestartWarningDialog(self).exec_()
+        self.needs_restart = False
         self.packages_search.clear()
         self.toggle_status(False)
         super().hideEvent(event)

--- a/src/napari_plugin_manager/qt_plugin_dialog.py
+++ b/src/napari_plugin_manager/qt_plugin_dialog.py
@@ -6,7 +6,6 @@ import napari.resources
 import npe2
 from napari._qt.qt_resources import QColoredSVGIcon, get_current_stylesheet
 from napari._qt.qthreading import create_worker
-from napari._qt.widgets.qt_message_popup import WarnPopup
 from napari._qt.widgets.qt_tooltip import QtToolTipLabel
 from napari.plugins.utils import normalized_name
 from napari.settings import get_settings
@@ -15,7 +14,7 @@ from napari.utils.misc import (
 )
 from napari.utils.notifications import show_info, show_warning
 from napari.utils.translations import trans
-from qtpy.QtCore import QPoint, QSize
+from qtpy.QtCore import QSize
 from qtpy.QtGui import (
     QMovie,
 )
@@ -41,24 +40,6 @@ from napari_plugin_manager.utils import is_conda_package
 # Scaling factor for each list widget item when expanding.
 STYLES_PATH = Path(__file__).parent / 'styles.qss'
 DISMISS_WARN_PYPI_INSTALL_DLG = False
-
-
-def _show_message(widget):
-    message = trans._(
-        'When installing/uninstalling npe2 plugins, '
-        'you must restart napari for UI changes to take effect.'
-    )
-    if widget.isVisible():
-        button = widget.action_button
-        warn_dialog = WarnPopup(text=message)
-        global_point = widget.action_button.mapToGlobal(
-            button.rect().topRight()
-        )
-        global_point = QPoint(
-            global_point.x() - button.width(), global_point.y()
-        )
-        warn_dialog.move(global_point)
-        warn_dialog.exec_()
 
 
 class ProjectInfoVersions(BaseProjectInfoVersions):
@@ -182,13 +163,6 @@ class QPluginList(BaseQPluginList):
     def _trans(self, text, **kwargs):
         return trans._(text, **kwargs)
 
-    def _before_handle_action(self, widget, action_name):
-        if (
-            widget.plugin_api_version != 1
-            and action_name == InstallerActions.UNINSTALL
-        ):
-            _show_message(widget)
-
 
 class QtPluginDialog(BaseQtPluginDialog):
 
@@ -248,8 +222,6 @@ class QtPluginDialog(BaseQtPluginDialog):
             if widget.name == pkg_name:
                 self.installed_list.scrollToItem(item)
                 self.installed_list.setCurrentItem(item)
-                if widget.plugin_api_version != 1:
-                    _show_message(widget)
                 break
 
     def _fetch_available_plugins(self, clear_cache: bool = False):

--- a/src/napari_plugin_manager/qt_plugin_dialog.py
+++ b/src/napari_plugin_manager/qt_plugin_dialog.py
@@ -222,7 +222,6 @@ class QtPluginDialog(BaseQtPluginDialog):
             if widget.name == pkg_name:
                 self.installed_list.scrollToItem(item)
                 self.installed_list.setCurrentItem(item)
-                self.needs_restart = True
                 break
 
     def _fetch_available_plugins(self, clear_cache: bool = False):

--- a/src/napari_plugin_manager/qt_plugin_dialog.py
+++ b/src/napari_plugin_manager/qt_plugin_dialog.py
@@ -222,6 +222,7 @@ class QtPluginDialog(BaseQtPluginDialog):
             if widget.name == pkg_name:
                 self.installed_list.scrollToItem(item)
                 self.installed_list.setCurrentItem(item)
+                self.needs_restart = True
                 break
 
     def _fetch_available_plugins(self, clear_cache: bool = False):

--- a/src/napari_plugin_manager/qt_warning_dialog.py
+++ b/src/napari_plugin_manager/qt_warning_dialog.py
@@ -1,0 +1,18 @@
+from qtpy.QtWidgets import QDialog, QLabel, QPushButton, QVBoxLayout, QWidget
+
+
+class RestartWarningDialog(QDialog):
+    def __init__(self, parent: QWidget) -> None:
+        super().__init__(parent)
+        self.setWindowTitle('Restart napari')
+        okay_btn = QPushButton('Okay')
+        self.restart_warning_text = """
+Restart napari after installing/uninstalling npe2 plugins.
+        """
+
+        okay_btn.clicked.connect(self.accept)
+
+        layout = QVBoxLayout()
+        layout.addWidget(QLabel(self.restart_warning_text))
+        layout.addWidget(okay_btn)
+        self.setLayout(layout)

--- a/src/napari_plugin_manager/qt_warning_dialog.py
+++ b/src/napari_plugin_manager/qt_warning_dialog.py
@@ -7,7 +7,8 @@ class RestartWarningDialog(QDialog):
         self.setWindowTitle('Restart napari')
         okay_btn = QPushButton('Okay')
         self.restart_warning_text = """
-Restart napari after installing/uninstalling npe2 plugins.
+Plugins have been installed or uninstalled. If you notice any
+issues with plugin functionality, you may need to restart napari.
         """
 
         okay_btn.clicked.connect(self.accept)

--- a/src/napari_plugin_manager/utils.py
+++ b/src/napari_plugin_manager/utils.py
@@ -3,6 +3,8 @@ import sys
 from pathlib import Path
 from typing import Optional
 
+from qtpy.QtWidgets import QDialog, QWidget
+
 
 def is_conda_package(pkg: str, prefix: Optional[str] = None) -> bool:
     """Determines if plugin was installed through conda.
@@ -20,3 +22,25 @@ def is_conda_package(pkg: str, prefix: Optional[str] = None) -> bool:
         re.match(rf"{pkg}-[^-]+-[^-]+.json", p.name)
         for p in conda_meta_dir.glob(f"{pkg}-*-*.json")
     )
+
+
+def get_dialog_from_widget(widget: QWidget) -> QDialog | None:
+    """Returns the parent dialog of the given widget.
+
+    Parameters
+    ----------
+    widget : QWidget
+        Widget to find parent for.
+
+    Returns
+    -------
+    QtPluginDialog | None
+        The dialog containing the given widget, if available
+    """
+    from napari_plugin_manager.qt_plugin_dialog import QtPluginDialog
+
+    while widget is not None:
+        if isinstance(widget, QtPluginDialog):
+            return widget
+        widget = widget.parent()
+    return None

--- a/src/napari_plugin_manager/utils.py
+++ b/src/napari_plugin_manager/utils.py
@@ -3,8 +3,6 @@ import sys
 from pathlib import Path
 from typing import Optional
 
-from qtpy.QtWidgets import QDialog, QWidget
-
 
 def is_conda_package(pkg: str, prefix: Optional[str] = None) -> bool:
     """Determines if plugin was installed through conda.
@@ -22,25 +20,3 @@ def is_conda_package(pkg: str, prefix: Optional[str] = None) -> bool:
         re.match(rf"{pkg}-[^-]+-[^-]+.json", p.name)
         for p in conda_meta_dir.glob(f"{pkg}-*-*.json")
     )
-
-
-def get_dialog_from_widget(widget: QWidget) -> QDialog | None:
-    """Returns the parent dialog of the given widget.
-
-    Parameters
-    ----------
-    widget : QWidget
-        Widget to find parent for.
-
-    Returns
-    -------
-    QtPluginDialog | None
-        The dialog containing the given widget, if available
-    """
-    from napari_plugin_manager.qt_plugin_dialog import QtPluginDialog
-
-    while widget is not None:
-        if isinstance(widget, QtPluginDialog):
-            return widget
-        widget = widget.parent()
-    return None


### PR DESCRIPTION
This removes the warning pop-up when installing and uninstalling npe2 plugins, and replaces it with a warning when the user closes the plugin dialog instead.