### PR TITLE
Change suffix of conda executable form `.bat` to `.exe`

### DIFF
--- a/src/napari_plugin_manager/base_qt_package_installer.py
+++ b/src/napari_plugin_manager/base_qt_package_installer.py
@@ -184,18 +184,18 @@ class CondaInstallerTool(AbstractInstallerTool):
 
         This method assumes that if no environment variable is set that conda is available in the PATH.
         """
-        bat = ".bat" if os.name == "nt" else ""
+        suffix = ".exe" if os.name == "nt" else ""
         for path in (
             Path(os.environ.get('MAMBA_EXE', '')),
             Path(os.environ.get('CONDA_EXE', '')),
             # $CONDA is usually only available on GitHub Actions
-            Path(os.environ.get('CONDA', '')) / 'condabin' / f'conda{bat}',
+            Path(os.environ.get('CONDA', '')) / 'condabin' / f'conda{suffix}',
         ):
             if path.is_file():
                 # return the path to the executable
                 return str(path)
         # Otherwise, we assume that conda is available in the PATH
-        return f'conda{bat}'
+        return f'conda{suffix}'
 
     @classmethod
     def available(cls):


### PR DESCRIPTION
Closes napari/packaging#233

As I checked the bundle installation for napari 0.6.0rc0, the `conda.bat` is not available, but `conda.exe` is. 

Checked locally that change of suffix from `.bat` to `.exe` solves the problem for me. 

For Windows, the `.exe` file is just a binary executable. The `.bat` is windows script. I do not see the advantage of `.bat` over `.exe` to prefer `.bat`.  