### PR TITLE
Parse `project_url` field for `home_page` link

### DIFF
--- a/src/napari_plugin_manager/_tests/test_npe2api.py
+++ b/src/napari_plugin_manager/_tests/test_npe2api.py
@@ -27,6 +27,7 @@ def test_plugin_summaries():
         "home_page",
         "pypi_versions",
         "conda_versions",
+        "project_url",
     ]
     try:
         data = plugin_summaries()

--- a/src/napari_plugin_manager/_tests/test_utils.py
+++ b/src/napari_plugin_manager/_tests/test_utils.py
@@ -3,7 +3,7 @@ from unittest.mock import patch
 
 import pytest
 
-from napari_plugin_manager.utils import is_conda_package
+from napari_plugin_manager.utils import get_homepage_url, is_conda_package
 
 
 @pytest.mark.parametrize(
@@ -25,3 +25,34 @@ def test_is_conda_package(pkg_name, expected, tmp_path):
 
     with patch.object(sys, 'prefix', tmp_path):
         assert is_conda_package(pkg_name) is expected
+
+
+def test_get_homepage_url():
+    assert get_homepage_url({}) == ''
+
+    meta = {
+        'Home-page': None,
+    }
+    assert get_homepage_url(meta) == ''
+
+    meta['Home-page'] = 'http://example.com'
+    assert get_homepage_url(meta) == 'http://example.com'
+
+    meta['Project-URL'] = ['Home Page, http://projurl.com']
+    assert get_homepage_url(meta) == 'http://example.com'
+
+    meta['home_page'] = meta.pop('Home-page')
+    meta['project_url'] = meta.pop('Project-URL')
+    assert get_homepage_url(meta) == 'http://example.com'
+
+    meta['home_page'] = None
+    assert get_homepage_url(meta) == 'http://projurl.com'
+
+    meta['project_url'] = ['Source Code, http://projurl.com']
+    assert get_homepage_url(meta) == 'http://projurl.com'
+
+    meta['project_url'] = ['Source, http://projurl.com']
+    assert get_homepage_url(meta) == 'http://projurl.com'
+
+    meta['project_url'] = None
+    assert get_homepage_url(meta) == ''

--- a/src/napari_plugin_manager/base_qt_plugin_dialog.py
+++ b/src/napari_plugin_manager/base_qt_plugin_dialog.py
@@ -53,7 +53,7 @@ from napari_plugin_manager.base_qt_package_installer import (
 )
 from napari_plugin_manager.qt_warning_dialog import RestartWarningDialog
 from napari_plugin_manager.qt_widgets import ClickableLabel
-from napari_plugin_manager.utils import is_conda_package
+from napari_plugin_manager.utils import get_homepage_url, is_conda_package
 
 CONDA = 'Conda'
 PYPI = 'PyPI'
@@ -1225,7 +1225,8 @@ class BaseQtPluginDialog(QDialog):
             self.already_installed.add(norm_name)
         else:
             meta = {}
-
+        meta_dict = meta if isinstance(meta, dict) else meta.json
+        home_page = get_homepage_url(meta_dict)
         self.installed_list.addItem(
             self.PROJECT_INFO_VERSION_CLASS(
                 display_name=norm_name,
@@ -1236,7 +1237,7 @@ class BaseQtPluginDialog(QDialog):
                     name=norm_name,
                     version=meta.get('version', ''),
                     summary=meta.get('summary', ''),
-                    home_page=meta.get('Home-page', ''),
+                    home_page=home_page,
                     author=meta.get('author', ''),
                     license=meta.get('license', ''),
                 ),

--- a/src/napari_plugin_manager/npe2api.py
+++ b/src/napari_plugin_manager/npe2api.py
@@ -19,6 +19,8 @@ from napari.utils.notifications import show_warning
 from npe2 import PackageMetadata
 from typing_extensions import NotRequired
 
+from napari_plugin_manager.utils import get_homepage_url
+
 PyPIname = str
 
 
@@ -98,12 +100,15 @@ def iter_napari_plugin_info() -> Iterator[tuple[PackageMetadata, bool, dict]]:
 
     conda_set = {normalized_name(x) for x in conda}
     for info in data_set:
-        info_copy = dict(info)
+        info_copy: dict[str, str | list[str]] = dict(info)
         info_copy.pop('display_name', None)
         pypi_versions = info_copy.pop('pypi_versions')
         conda_versions = info_copy.pop('conda_versions')
         info_ = cast(_ShortSummaryDict, info_copy)
-
+        home_page = get_homepage_url(info_copy)
+        # this URL is used for the widget, so we have to replace the home_page
+        # link here as well as returning it in extra_info
+        info_['home_page'] = home_page
         # TODO: use this better.
         # this would require changing the api that qt_plugin_dialog expects to
         # receive
@@ -111,7 +116,7 @@ def iter_napari_plugin_info() -> Iterator[tuple[PackageMetadata, bool, dict]]:
         # TODO: once the new version of npe2 is out, this can be refactored
         # to all the metadata includes the conda and pypi versions.
         extra_info = {
-            'home_page': info_.get('home_page', ''),
+            'home_page': home_page,
             'display_name': info.get('display_name', ''),
             'pypi_versions': pypi_versions,
             'conda_versions': conda_versions,

--- a/src/napari_plugin_manager/utils.py
+++ b/src/napari_plugin_manager/utils.py
@@ -1,4 +1,5 @@
 import re
+import string
 import sys
 from pathlib import Path
 
@@ -19,3 +20,57 @@ def is_conda_package(pkg: str, prefix: str | None = None) -> bool:
         re.match(rf"{pkg}-[^-]+-[^-]+.json", p.name)
         for p in conda_meta_dir.glob(f"{pkg}-*-*.json")
     )
+
+
+def normalize_label(label: str) -> str:
+    """Normalize project URL label.
+
+    Code reproduced from:
+    https://packaging.python.org/en/latest/specifications/well-known-project-urls/#label-normalization
+    """
+    chars_to_remove = string.punctuation + string.whitespace
+    removal_map = str.maketrans("", "", chars_to_remove)
+    return label.translate(removal_map).lower()
+
+
+def get_homepage_url(metadata: dict[str, str | list[str]]) -> str:
+    """Get URL for package homepage, if available.
+
+    Checks metadata first for `Home-page` field before
+    looking for `Project-URL` 'homepage' label and finally
+    'source'/'sourcecode' label.
+
+    Parameters
+    ----------
+    metadata : dict[str, str | list[str]]
+        Package metadata information.
+
+    Returns
+    -------
+    str
+        Returns homepage URL if present, otherwise empty string.
+    """
+    if not len(metadata):
+        return ''
+
+    homepage = metadata.get('Home-page', '') or metadata.get('home_page', '')
+    if isinstance(homepage, str) and len(homepage):
+        return homepage
+
+    urls = {}
+    project_urls = metadata.get('Project-URL', []) or metadata.get(
+        'project_url', []
+    )
+    if project_urls is None:
+        return ''
+
+    for url_info in project_urls:
+        label, url = url_info.split(', ')
+        urls[normalize_label(label)] = url
+
+    homepage = (
+        urls.get('homepage', '')
+        or urls.get('source', '')
+        or urls.get('sourcecode', '')
+    )
+    return homepage

--- a/src/napari_plugin_manager/utils.py
+++ b/src/napari_plugin_manager/utils.py
@@ -33,7 +33,7 @@ def normalize_label(label: str) -> str:
     return label.translate(removal_map).lower()
 
 
-def get_homepage_url(metadata: dict[str, str | list[str]]) -> str:
+def get_homepage_url(metadata: dict[str, str | list[str] | None]) -> str:
     """Get URL for package homepage, if available.
 
     Checks metadata first for `Home-page` field before
@@ -42,7 +42,7 @@ def get_homepage_url(metadata: dict[str, str | list[str]]) -> str:
 
     Parameters
     ----------
-    metadata : dict[str, str | list[str]]
+    metadata : dict[str, str | list[str] | None]
         Package metadata information.
 
     Returns


### PR DESCRIPTION
Prior to this PR, only the now-deprecated `Home-page` field of the metadata would be used to determine the clickable project link in the plugin listing. This means any plugins declaring the new standard field, `Project-URL` would not get their link associated. This affects all plugins using only `pyproject.toml` for their metadata spec, and any plugins created using the plugin template.

In this PR I update the logic to check the `Project-URL` field for a homepage link if one is not present under `Home-page`. We check all project urls for either a `homepage` or `sourcecode` link.

Note that since we parse npe2api metadata before install, and importlib metadata after install, the utility function checks for a couple of different "formats" of the fields e.g. `Project-URL` **and** `project_url`.

To test this PR:

1. Install `napari-plugin-manager` from this branch.
2. Launch `napari`, open the `Install/Uninstall Plugins` dialog
3. Search for a plugin that declares URLS only in `pyproject.toml`. Known plugins: `napari-zplane-depth-colorizer`, `napari-sam2long`, `napari-zelda`, `frontveg`, new plugin generated with template.
4. The plugin listing should have a clickable name:

![image](https://github.com/user-attachments/assets/dbc863cc-d9d7-47b4-bd31-4b0e1b849f77)

5. Install plugin
6. Name should still be clickable