### PR TITLE
CI: add `normalized_name` to `test_plugin_summaries`, increase timeouts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ __pycache__/
 
 # Distribution / packaging
 .Python
+.venv/
 env/
 build/
 develop-eggs/
@@ -119,3 +120,5 @@ target/
 # Images
 docs/images/
 
+# UV Lockfiles
+uv.lock

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,6 +49,7 @@ classifiers = [
 ]
 requires-python = ">=3.10"
 dependencies = [
+  "napari",  # FUTURE: Fully decouple from napari
   "npe2",
   "qtpy",
   "superqt",
@@ -69,7 +70,7 @@ testing = [
   "coverage",
   "flaky",
   "pytest",
-  "pytest-qt",
+  "pytest-qt<4.5",  # FUTURE: Unpin once pyside2 is dropped
   "virtualenv"
 ]
 

--- a/src/napari_plugin_manager/_tests/test_installer_process.py
+++ b/src/napari_plugin_manager/_tests/test_installer_process.py
@@ -75,7 +75,7 @@ def test_pip_installer_tasks(
         "origins",
         ("https://pypi.org/simple",),
     )
-    with qtbot.waitSignal(installer.allFinished, timeout=20000):
+    with qtbot.waitSignal(installer.allFinished, timeout=30_000):
         installer.install(
             tool=InstallerTools.PIP,
             pkgs=['pip-install-test'],
@@ -104,7 +104,7 @@ def test_pip_installer_tasks(
 
     assert pkgs >= 2, 'package was not installed'
 
-    with qtbot.waitSignal(installer.allFinished, timeout=10000):
+    with qtbot.waitSignal(installer.allFinished, timeout=30_000):
         job_id = installer.uninstall(
             tool=InstallerTools.PIP,
             pkgs=['pip-install-test'],
@@ -117,7 +117,7 @@ def test_pip_installer_tasks(
     assert not installer.hasJobs()
 
     # Test new signals
-    with qtbot.waitSignal(installer.processFinished, timeout=20000) as blocker:
+    with qtbot.waitSignal(installer.processFinished, timeout=30_000) as blocker:
         installer.install(
             tool=InstallerTools.PIP,
             pkgs=['pydantic'],
@@ -127,7 +127,7 @@ def test_pip_installer_tasks(
     assert process_finished_data['pkgs'] == ["pydantic"]
 
     # Test upgrade
-    with qtbot.waitSignal(installer.allFinished, timeout=20000):
+    with qtbot.waitSignal(installer.allFinished, timeout=30_000):
         installer.install(
             tool=InstallerTools.PIP,
             pkgs=['requests==2.30.0'],
@@ -169,7 +169,7 @@ def test_installer_failures(qtbot, tmp_virtualenv: 'Session', monkeypatch):
     )
 
     # CHECK 1) Errors should trigger finished and allFinished too
-    with qtbot.waitSignal(installer.allFinished, timeout=10000):
+    with qtbot.waitSignal(installer.allFinished, timeout=10_000):
         installer.install(
             tool=InstallerTools.PIP,
             pkgs=[f'this-package-does-not-exist-{hash(time.time())}'],
@@ -184,7 +184,7 @@ def test_installer_failures(qtbot, tmp_virtualenv: 'Session', monkeypatch):
         "_on_process_done",
         MethodType(_assert_exit_code_not_zero, installer),
     )
-    with qtbot.waitSignal(installer.allFinished, timeout=10000):
+    with qtbot.waitSignal(installer.allFinished, timeout=10_000):
         installer.install(
             tool=InstallerTools.PIP,
             pkgs=[f'this-package-does-not-exist-{hash(time.time())}'],
@@ -197,7 +197,7 @@ def test_installer_failures(qtbot, tmp_virtualenv: 'Session', monkeypatch):
         MethodType(_assert_error_used, installer),
     )
     monkeypatch.setattr(installer, "_get_tool", lambda *a: _NonExistingTool)
-    with qtbot.waitSignal(installer.allFinished, timeout=10000):
+    with qtbot.waitSignal(installer.allFinished, timeout=10_000):
         installer.install(
             tool=_NonExistingTool,
             pkgs=[f'this-package-does-not-exist-{hash(time.time())}'],
@@ -206,7 +206,7 @@ def test_installer_failures(qtbot, tmp_virtualenv: 'Session', monkeypatch):
 
 def test_cancel_incorrect_job_id(qtbot, tmp_virtualenv: 'Session'):
     installer = NapariInstallerQueue()
-    with qtbot.waitSignal(installer.allFinished, timeout=20000):
+    with qtbot.waitSignal(installer.allFinished, timeout=30_000):
         job_id = installer.install(
             tool=InstallerTools.PIP,
             pkgs=['requests'],
@@ -335,7 +335,7 @@ def test_conda_installer_wait_for_finished(qtbot, tmp_conda_env: Path):
             pkgs=['pyzenhub'],
             prefix=tmp_conda_env,
         )
-        installer.waitForFinished(20000)
+        installer.waitForFinished(30_000)
 
 
 def test_constraints_are_in_sync():

--- a/src/napari_plugin_manager/_tests/test_npe2api.py
+++ b/src/napari_plugin_manager/_tests/test_npe2api.py
@@ -19,6 +19,7 @@ def test_user_agent():
 def test_plugin_summaries():
     keys = [
         "name",
+        "normalized_name",
         "version",
         "display_name",
         "summary",

--- a/src/napari_plugin_manager/_tests/test_qt_plugin_dialog.py
+++ b/src/napari_plugin_manager/_tests/test_qt_plugin_dialog.py
@@ -468,8 +468,8 @@ def test_drop_event(plugin_dialog, tmp_path):
 
 
 @pytest.mark.skipif(
-    'napari_latest' in os.getenv('TOX_ENV_NAME')
-    and 'PySide2' in os.getenv('TOX_ENV_NAME'),
+    'napari_latest' in os.getenv('TOX_ENV_NAME', '')
+    and 'PySide2' in os.getenv('TOX_ENV_NAME', ''),
     reason='PySide2 flaky with latest released napari',
 )
 def test_installs(qtbot, tmp_virtualenv, plugin_dialog, request):


### PR DESCRIPTION
Part of https://github.com/napari/napari-plugin-manager/issues/159, probably needed due to https://github.com/napari/npe2api/pull/52.

cc @Czaki  