### PR TITLE
Update tests to pass ruff check, try to decrease `test_cancel_all` segfaults and update PySide 6 version

### DIFF
--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -103,8 +103,6 @@ jobs:
           NAPARI: ${{ matrix.napari }}
           TOOL: ${{ matrix.tool }}
           FORCE_COLOR: 1
-          # Only supported pyside6 is not supported on py312, py313
-          TOX_SKIP_ENV: ".*py31[23].*PySide6"
           
       - name: Test with tox - conda
         if: matrix.tool == 'conda'
@@ -119,7 +117,7 @@ jobs:
           FORCE_COLOR: 1
           # Only supported pyside2 and pyside6 are not supported on py312, py313
           # no Qt backends supported by conda-forge on py313
-          TOX_SKIP_ENV: ".*py31[23].*PySide[26]|.*py313.*conda"
+          TOX_SKIP_ENV: ".*py31[23].*PySide2|.*py313.*conda"
 
           
       - name: Upload coverage data

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,8 +70,7 @@ testing = [
   "coverage",
   "flaky",
   "pytest",
-  "pytest-qt<4.5; python_version<'3.11'",  # FUTURE: Unpin once pyside2 is dropped
-  "pytest-qt; python_version>='3.11'",
+  "pytest-qt<4.5",  # FUTURE: Unpin once pyside2 is dropped
   "virtualenv"
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,7 +70,8 @@ testing = [
   "coverage",
   "flaky",
   "pytest",
-  "pytest-qt<4.5",  # FUTURE: Unpin once pyside2 is dropped
+  "pytest-qt<4.5; python_version<'3.11'",  # FUTURE: Unpin once pyside2 is dropped
+  "pytest-qt; python_version>='3.11'",
   "virtualenv"
 ]
 

--- a/src/napari_plugin_manager/_tests/test_installer_process.py
+++ b/src/napari_plugin_manager/_tests/test_installer_process.py
@@ -148,17 +148,17 @@ def test_pip_installer_invalid_action(tmp_virtualenv: 'Session', monkeypatch):
         lambda *a: tmp_virtualenv.creator.exe,
     )
     invalid_action = 'Invalid Action'
+    item = installer._build_queue_item(
+        tool=InstallerTools.PIP,
+        action=invalid_action,
+        pkgs=['pip-install-test'],
+        prefix=None,
+        origins=(),
+        process=installer._create_process(),
+    )
     with pytest.raises(
         ValueError, match=f"Action '{invalid_action}' not supported!"
     ):
-        item = installer._build_queue_item(
-            tool=InstallerTools.PIP,
-            action=invalid_action,
-            pkgs=['pip-install-test'],
-            prefix=None,
-            origins=(),
-            process=installer._create_process(),
-        )
         installer._queue_item(item)
 
 
@@ -213,7 +213,7 @@ def test_cancel_incorrect_job_id(qtbot, tmp_virtualenv: 'Session'):
             tool=InstallerTools.PIP,
             pkgs=['requests'],
         )
-        with pytest.raises(ValueError):
+        with pytest.raises(ValueError, match=f'No job with id {job_id + 1}.'):
             installer.cancel(job_id + 1)
 
 
@@ -366,5 +366,7 @@ def test_available():
 
 
 def test_unrecognized_tool():
-    with pytest.raises(ValueError):
+    with pytest.raises(
+        ValueError, match='InstallerTool shrug not recognized!'
+    ):
         NapariInstallerQueue().install(tool='shrug', pkgs=[])

--- a/src/napari_plugin_manager/_tests/test_qt_plugin_dialog.py
+++ b/src/napari_plugin_manager/_tests/test_qt_plugin_dialog.py
@@ -188,15 +188,18 @@ def plugin_dialog(
         widget, '_is_main_app_conda_package', lambda: request.param
     )
     # monkeypatch.setattr(widget, '_tag_outdated_plugins', lambda: None)
-    widget.show()
-    qtbot.waitUntil(widget.isVisible, timeout=300)
+    with qtbot.waitExposed(widget):
+        widget.show()
 
+    assert widget.isVisible()
     assert widget.available_list.count_visible() == 0
     assert widget.available_list.count() == 0
     qtbot.add_widget(widget)
     yield widget
     widget.hide()
     widget._add_items_timer.stop()
+    if widget.worker is not None:
+        widget.worker.quit()
     assert not widget._add_items_timer.isActive()
     get_settings().plugins.use_npe2_adaptor = original_setting
 

--- a/tox.ini
+++ b/tox.ini
@@ -44,7 +44,7 @@ deps =
     PyQt5: PyQt5
     PyQt5: PyQt5-sip
     PyQt6: PyQt6
-    {py310,py311}-PySide6: PySide6 == 6.4.2 
+    {py310,py311}-PySide6: PySide6
     napari_latest: napari
     napari_repo: git+https://github.com/napari/napari.git
 

--- a/tox.ini
+++ b/tox.ini
@@ -44,7 +44,7 @@ deps =
     PyQt5: PyQt5
     PyQt5: PyQt5-sip
     PyQt6: PyQt6
-    {py310,py311}-PySide6: PySide6 > 6.7
+    PySide6: PySide6 > 6.7
     napari_latest: napari
     napari_repo: git+https://github.com/napari/napari.git
 
@@ -53,5 +53,5 @@ deps =
 conda_deps =
     {py310,py311,py312}-PyQt5: pyqt
     {py310,py311}-PySide2: pyside2
-    {py310,py311}-PySide6: pyside6 > 6.7
+    PySide6: pyside6 > 6.7
     napari_latest: napari

--- a/tox.ini
+++ b/tox.ini
@@ -44,7 +44,7 @@ deps =
     PyQt5: PyQt5
     PyQt5: PyQt5-sip
     PyQt6: PyQt6
-    {py310,py311}-PySide6: PySide6
+    {py310,py311}-PySide6: PySide6 > 6.7
     napari_latest: napari
     napari_repo: git+https://github.com/napari/napari.git
 
@@ -53,5 +53,5 @@ deps =
 conda_deps =
     {py310,py311,py312}-PyQt5: pyqt
     {py310,py311}-PySide2: pyside2
-    {py310,py311}-PySide6: pyside6 = 6.4.2
+    {py310,py311}-PySide6: pyside6 > 6.7
     napari_latest: napari


### PR DESCRIPTION
Part of #159

* Fixes for ruff checks:

```
src/napari_plugin_manager/_tests/test_installer_process.py:149:5: PT012 `pytest.raises()` block should contain a single simple statement
    |
147 |       )
148 |       invalid_action = 'Invalid Action'
149 | /     with pytest.raises(
150 | |         ValueError, match=f"Action '{invalid_action}' not supported!"
151 | |     ):
152 | |         item = installer._build_queue_item(
153 | |             tool=InstallerTools.PIP,
154 | |             action=invalid_action,
155 | |             pkgs=['pip-install-test'],
156 | |             prefix=None,
157 | |             origins=(),
158 | |             process=installer._create_process(),
159 | |         )
160 | |         installer._queue_item(item)
    | |___________________________________^ PT012
    |
```

```
src/napari_plugin_manager/_tests/test_installer_process.py:214:28: PT011 `pytest.raises(ValueError)` is too broad, set the `match` parameter or use a more specific exception
    |
212 |             pkgs=['requests'],
213 |         )
214 |         with pytest.raises(ValueError):
    |                            ^^^^^^^^^^ PT011
215 |             installer.cancel(job_id + 1)
    |
```

```
src/napari_plugin_manager/_tests/test_installer_process.py:367:24: PT011 `pytest.raises(ValueError)` is too broad, set the `match` parameter or use a more specific exception
    |
366 | def test_unrecognized_tool():
367 |     with pytest.raises(ValueError):
    |                        ^^^^^^^^^^ PT011
368 |         NapariInstallerQueue().install(tool='shrug', pkgs=[])

```

* Some changes for tests:
   * Use PySide6 > 6.7
   * Update `plugin_dialog` fixture quittin worker explicitly and changing some logic to check for dialog visibility before proceding