### PR TITLE
Show restart warning dialog also when updating plugins

### DIFF
--- a/src/napari_plugin_manager/_tests/test_qt_plugin_dialog.py
+++ b/src/napari_plugin_manager/_tests/test_qt_plugin_dialog.py
@@ -172,6 +172,10 @@ def plugin_dialog(
         _iter_napari_pypi_plugin_info,
     )
 
+    monkeypatch.setattr(
+        base_qt_plugin_dialog, 'RestartWarningDialog', MagicMock()
+    )
+
     # This is patching `napari.utils.misc.running_as_constructor_app` function
     # to mock a normal napari install.
     monkeypatch.setattr(
@@ -335,26 +339,16 @@ def test_plugin_list_handle_action(plugin_dialog, qtbot):
     qtbot.waitUntil(lambda: not plugin_dialog.worker.is_running)
 
 
-def test_plugin_install_restart_warning(plugin_dialog, monkeypatch):
+def test_plugin_restart_warning(plugin_dialog, monkeypatch):
     dialog_mock = MagicMock()
     monkeypatch.setattr(
         base_qt_plugin_dialog, 'RestartWarningDialog', dialog_mock
     )
     plugin_dialog.exec_()
-    plugin_dialog.already_installed.add('brand-new-plugin')
+    plugin_dialog.modified_set.add('added-removed-updated-plugin')
     plugin_dialog.hide()
     dialog_mock.assert_called_once()
-
-
-def test_plugin_uninstall_restart_warning(plugin_dialog, monkeypatch):
-    dialog_mock = MagicMock()
-    monkeypatch.setattr(
-        base_qt_plugin_dialog, 'RestartWarningDialog', dialog_mock
-    )
-    plugin_dialog.exec_()
-    plugin_dialog.already_installed.remove('my-plugin')
-    plugin_dialog.hide()
-    dialog_mock.assert_called_once()
+    assert len(plugin_dialog.modified_set) == 0
 
 
 def test_on_enabled_checkbox(plugin_dialog, qtbot, plugins, old_plugins):

--- a/src/napari_plugin_manager/base_qt_plugin_dialog.py
+++ b/src/napari_plugin_manager/base_qt_plugin_dialog.py
@@ -839,7 +839,6 @@ class BaseQPluginList(QListWidget):
         widget = item.widget
         tool = installer_choice or widget.get_installer_tool()
         self._remove_list.append((pkg_name, item))
-        self._warn_dialog = None
         if not item.text().startswith(self._SORT_ORDER_PREFIX):
             item.setText(f'{self._SORT_ORDER_PREFIX}{item.text()}')
 
@@ -856,8 +855,6 @@ class BaseQPluginList(QListWidget):
                 # origins="TODO",
             )
             widget.setProperty('current_job_id', job_id)
-            if self._warn_dialog:
-                self._warn_dialog.exec_()
             self.scrollToTop()
 
         if action_name == InstallerActions.UPGRADE:
@@ -874,8 +871,6 @@ class BaseQPluginList(QListWidget):
                 # origins="TODO",
             )
             widget.setProperty('current_job_id', job_id)
-            if self._warn_dialog:
-                self._warn_dialog.exec_()
             self.scrollToTop()
 
         elif action_name == InstallerActions.UNINSTALL:
@@ -888,8 +883,6 @@ class BaseQPluginList(QListWidget):
                 # upgrade=False,
             )
             widget.setProperty('current_job_id', job_id)
-            if self._warn_dialog:
-                self._warn_dialog.exec_()
             self.scrollToTop()
         elif action_name == InstallerActions.CANCEL:
             widget.set_busy(self._trans('cancelling...'), action_name)
@@ -1042,6 +1035,7 @@ class BaseQtPluginDialog(QDialog):
         self._plugins_found = 0
         self.already_installed = set()
         self.available_set = set()
+        self.modified_set = set()
         self._prefix = prefix
         self._first_open = True
         self._plugin_queue = []  # Store plugin data to be added
@@ -1152,6 +1146,7 @@ class BaseQtPluginDialog(QDialog):
 
                     self.available_list.removeItem(pkg_name)
                     self._add_installed(pkg_name)
+                    self.modified_set.add(pkg_name)
                     self._tag_outdated_plugins()
             else:
                 for pkg_name in pkg_names:
@@ -1164,6 +1159,7 @@ class BaseQtPluginDialog(QDialog):
 
                     self.installed_list.removeItem(pkg_name)
                     self._add_to_available(pkg_name)
+                    self.modified_set.add(pkg_name)
             else:
                 for pkg_name in pkg_names:
                     self.installed_list.refreshItem(pkg_name)
@@ -1177,6 +1173,7 @@ class BaseQtPluginDialog(QDialog):
                     self.installed_list.refreshItem(
                         pkg_name, version=pkg_version
                     )
+                    self.modified_set.add(pkg_name)
                 else:
                     self.installed_list.refreshItem(pkg)
                 self._tag_outdated_plugins()
@@ -1744,17 +1741,17 @@ class BaseQtPluginDialog(QDialog):
 
         plugin_dialog.setModal(True)
         plugin_dialog.show()
-        plugin_dialog._installed_on_show = set(plugin_dialog.already_installed)
 
         if self._first_open:
             self._update_theme(None)
             self._first_open = False
 
     def hideEvent(self, event):
-        if (
-            hasattr(self, '_installed_on_show')
-            and self._installed_on_show != self.already_installed
-        ):
+        if len(self.modified_set):
+            # At least one plugin was installed, uninstalled or updated so
+            # clear modified packages (to show warning only once) and
+            # show restart warning
+            self.modified_set = set()
             RestartWarningDialog(self).exec_()
         self.packages_search.clear()
         self.toggle_status(False)

--- a/src/napari_plugin_manager/qt_warning_dialog.py
+++ b/src/napari_plugin_manager/qt_warning_dialog.py
@@ -9,8 +9,8 @@ class RestartWarningDialog(QDialog):
         self.setWindowTitle('Restart napari')
         okay_btn = QPushButton('Okay')
         self.restart_warning_text = """
-            Plugins have been modified. If you notice any issues with plugin
-            functionality, you may need to restart napari.
+            Plugins have been added/removed or updated. If you notice any issues
+            with plugin functionality, you may need to restart napari.
         """
 
         okay_btn.clicked.connect(self.accept)

--- a/src/napari_plugin_manager/qt_warning_dialog.py
+++ b/src/napari_plugin_manager/qt_warning_dialog.py
@@ -7,7 +7,7 @@ class RestartWarningDialog(QDialog):
         self.setWindowTitle('Restart napari')
         okay_btn = QPushButton('Okay')
         self.restart_warning_text = """
-Plugins have been installed or uninstalled. If you notice any
+Plugins have been installed, uninstalled or updated. If you notice any
 issues with plugin functionality, you may need to restart napari.
         """
 

--- a/src/napari_plugin_manager/qt_warning_dialog.py
+++ b/src/napari_plugin_manager/qt_warning_dialog.py
@@ -1,3 +1,5 @@
+import textwrap
+
 from qtpy.QtWidgets import QDialog, QLabel, QPushButton, QVBoxLayout, QWidget
 
 
@@ -7,13 +9,13 @@ class RestartWarningDialog(QDialog):
         self.setWindowTitle('Restart napari')
         okay_btn = QPushButton('Okay')
         self.restart_warning_text = """
-Plugins have been installed, uninstalled or updated. If you notice any
-issues with plugin functionality, you may need to restart napari.
+            Plugins have been modified. If you notice any issues with plugin
+            functionality, you may need to restart napari.
         """
 
         okay_btn.clicked.connect(self.accept)
 
         layout = QVBoxLayout()
-        layout.addWidget(QLabel(self.restart_warning_text))
+        layout.addWidget(QLabel(textwrap.dedent(self.restart_warning_text)))
         layout.addWidget(okay_btn)
         self.setLayout(layout)


### PR DESCRIPTION
Closes #145 

* Show restart warning dialog also when updating plugins
* Update restart warning dialog message
* Remove some old `_warn_dialog` related code.
* Update tests

A preview:

![show_restart_dialog](https://github.com/user-attachments/assets/bbb48f3b-202d-4fa5-bfaf-94831bd9a337)
