### PR TITLE
Fix CI: use macos-15 not macos-latest, drop py3.10

### DIFF
--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -31,7 +31,7 @@ jobs:
       fail-fast: false
       matrix:
         platform: [ubuntu-latest, windows-latest, macos-15]
-        python-version: ["3.10", "3.12"]
+        python-version: ["3.11", "3.12"]
         napari: ["latest", "repo", '0.6.6']
         tool: ["pip", "conda"]
         include:

--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -30,7 +30,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        platform: [ubuntu-latest, windows-latest, macos-latest]
+        platform: [ubuntu-latest, windows-latest, macos-15]
         python-version: ["3.10", "3.12"]
         napari: ["latest", "repo", '0.6.6']
         tool: ["pip", "conda"]
@@ -58,7 +58,7 @@ jobs:
           napari: repo
         - platform: macos-15-intel
           napari: repo
-        - platform: macos-latest
+        - platform: macos-15
           napari: repo
 
     steps:

--- a/tox.ini
+++ b/tox.ini
@@ -1,12 +1,12 @@
 # For more information about tox, see https://tox.readthedocs.io/en/latest/
 [tox]
-envlist = pip-py{310,312,313}-{PyQt5,PyQt6,PySide6}-napari_{latest,repo,066}, conda-{py310,py312,py313}-{PyQt5,PySide6}-napari_{latest,repo,066}
+envlist = pip-py{311,312,313}-{PyQt5,PyQt6,PySide6}-napari_{latest,repo,066}, conda-{py311,py312,py313}-{PyQt5,PySide6}-napari_{latest,repo,066}
 toxworkdir=/tmp/.tox
 isolated_build = true
 
 [gh-actions]
 python =
-    3.10: py310
+    3.11: py311
     3.12: py312
     3.13: py313
 
@@ -39,7 +39,7 @@ extras = testing
 commands = coverage run --parallel-mode -m pytest -v --color=yes
 
 # Conditional PIP dependencies based on environment variables
-[testenv:pip-{py310,py312,py313}-{PyQt5,PyQt6,PySide6}-napari_{latest,repo,066}]
+[testenv:pip-{py311,py312,py313}-{PyQt5,PyQt6,PySide6}-napari_{latest,repo,066}]
 deps =
     PyQt5: PyQt5
     PyQt5: PyQt5-sip
@@ -51,9 +51,9 @@ deps =
 
 
 # Conditional dependencies for CONDA
-[testenv:conda-{py310,py312}-{PyQt5,PySide6}-napari_{latest,repo,066}]
+[testenv:conda-{py311,py312}-{PyQt5,PySide6}-napari_{latest,repo,066}]
 conda_deps =
-    {py310,py312}-PyQt5: pyqt
+    {py311,py312}-PyQt5: pyqt
     PySide6: pyside6 > 6.7
     napari_latest: napari
     napari_066: napari==0.6.6


### PR DESCRIPTION
As we can see in #213, CI is currently red. @Czaki reckons it's the same failure as we were seeing on main with macos-latest. For now, this PR updates CI to run on macos-15 so we can go green.

Additionally, napari has dropped python 3.10, so this PR also drops it from this repo, so we can get CI green again.