### PR TITLE
fix: strengthen restart warning after plugin changes

### DIFF
--- a/src/napari_plugin_manager/qt_warning_dialog.py
+++ b/src/napari_plugin_manager/qt_warning_dialog.py
@@ -9,8 +9,7 @@ class RestartWarningDialog(QDialog):
         self.setWindowTitle('Restart napari')
         okay_btn = QPushButton('Okay')
         self.restart_warning_text = """
-            Plugins have been added/removed or updated. If you notice any issues
-            with plugin functionality, you may need to restart napari.
+            Plugins have been added/removed or updated. Please restart napari.
         """
 
         okay_btn.clicked.connect(self.accept)


### PR DESCRIPTION
## Summary
Strengthen the post-plugin-change restart dialog copy so users are clearly told to restart napari.

## Changes
- Update `RestartWarningDialog.restart_warning_text` to the wording requested in #217

Closes #217
